### PR TITLE
Add additional help message for invalid exercise names in `workout /new`

### DIFF
--- a/src/main/java/commands/WorkoutCommand.java
+++ b/src/main/java/commands/WorkoutCommand.java
@@ -114,7 +114,7 @@ public class WorkoutCommand extends Command {
 
         } catch (InvalidExerciseException e) {
             System.out.println(e.getMessage());
-            System.out.println("Please try again.");
+            System.out.println("Please try again. Enter 'exercise /list' for a list\nof available exercises.");
 
         } catch (InvalidWorkoutException e) {
             System.out.println(e.getMessage());


### PR DESCRIPTION
This PR contains code to print additional feedback whenever the user enters an invalid exercise name in `workout /new`.

Sample screenshot:
![image](https://user-images.githubusercontent.com/30099983/158118151-a91216c9-7551-45e3-bfa5-80cce35ef732.png)

In addition, some grammar issues and typos were fixed in the user guide.