### PR TITLE
Create Unique ID System for Workouts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/data/workouts/WorkoutList.java
+++ b/src/main/java/data/workouts/WorkoutList.java
@@ -318,8 +318,8 @@ public class WorkoutList {
             throw new InvalidWorkoutException(className, InvalidWorkoutException.INVALID_REPS_VALUE_ERROR_MSG);
         }
 
-        Workout updatedWorkout = getWorkoutFromIndexNum(indexToUpdate);
-        String exerciseName = updatedWorkout.getExerciseName();
+        Workout workoutToUpdate = getWorkoutFromIndexNum(indexToUpdate);
+        String exerciseName = workoutToUpdate.getExerciseName();
         boolean isExistingWorkout = checkForExistingWorkout(exerciseName, newRepsValue);
 
         if (isExistingWorkout) {
@@ -329,10 +329,11 @@ public class WorkoutList {
         }
 
         assert (isIndexToUpdateValid && isNewRepsValueValid && !isExistingWorkout);
-        String oldWorkoutKey = updatedWorkout.toString();
+        String oldWorkoutKey = workoutToUpdate.toString();
+        Workout updatedWorkout = workoutToUpdate;
         updatedWorkout.setRepetitions(newRepsValue);
         updateWorkoutsHashMapList(oldWorkoutKey, updatedWorkout);
-        logger.exiting(getClass().getName(), "updateWorkout");
+        logger.exiting(getClass().getName(), "Finished updating workout.");
         return updatedWorkout;
     }
 

--- a/src/main/java/data/workouts/WorkoutList.java
+++ b/src/main/java/data/workouts/WorkoutList.java
@@ -19,8 +19,8 @@ public class WorkoutList {
     public static final int MAX_DISPLAY = 10;
 
     private ExerciseList exerciseList;
-    private HashMap<String, Workout> workoutsList = new HashMap<>();
-    private ArrayList<Workout> workoutsDisplayList = new ArrayList<>();
+    private HashMap<String, Workout> workoutsHashMapList = new HashMap<>();
+    private ArrayList<String> workoutsDisplayList = new ArrayList<>();
     private static Logger logger = Logger.getLogger(WorkoutList.class.getName());
 
     /**
@@ -33,12 +33,37 @@ public class WorkoutList {
     }
 
     /**
-     * Gets the list of workouts.
+     * Gets the ArrayList of keys of Workout objects.
      *
-     * @return An ArrayList of Workouts.
+     * @return An ArrayList of keys of Workout objects.
      */
-    public ArrayList<Workout> getWorkoutsDisplayList() {
+    public ArrayList<String> getWorkoutsDisplayList() {
         return this.workoutsDisplayList;
+    }
+
+    /**
+     * Gets the HashMap of Workout objects.
+     *
+     * @return A HashMap of Workout objects.
+     */
+    public HashMap<String, Workout> getWorkoutsHashMapList() {
+        return this.workoutsHashMapList;
+    }
+
+    /**
+     * Retrieves the Workout object from the HashMap workoutsHashMapList based on the index number
+     * of the object stored in workoutsDisplayList. This index number is the number shown in
+     * 'workout /list'.
+     *
+     * @param indexNum The index number of the workout as shown in 'workout /list'.
+     * @return The Workout object that corresponds to the index number.
+     */
+    public Workout getWorkoutFromIndexNum(int indexNum) {
+        int elementNum = indexNum - 1;
+        assert (elementNum >= 0);
+        String keyValue = getWorkoutsDisplayList().get(elementNum);
+        Workout workoutObject = workoutsHashMapList.get(keyValue);
+        return workoutObject;
     }
 
     /**
@@ -88,7 +113,10 @@ public class WorkoutList {
         Workout newWorkout = new Workout(userExerciseInput, userRepsInput);
         logger.log(Level.INFO, "New workout created.");
 
-        workoutsDisplayList.add(newWorkout);
+        String newWorkoutKey = newWorkout.toString();
+        workoutsHashMapList.put(newWorkoutKey, newWorkout);
+
+        workoutsDisplayList.add(newWorkoutKey);
 
         return newWorkout;
     }
@@ -131,6 +159,7 @@ public class WorkoutList {
 
         if (totalPrints > 0) {
             continuousPrinting(index, totalPrints);
+            System.out.println();
             System.out.println("Showed all workouts in list");
             return;
         } else {
@@ -146,9 +175,11 @@ public class WorkoutList {
     public int continuousPrinting(int index, int noOfPrints) {
         System.out.println("Showing workouts " + (index + 1) + "-" + (index + noOfPrints)
                 + " of " + workoutsDisplayList.size() + ":");
+        System.out.println();
         assert (noOfPrints <= workoutsDisplayList.size());
         for (int i = 0; i < noOfPrints; i++) {
-            System.out.println(index + 1 + ". " + workoutsDisplayList.get(index));
+            Workout workoutObject = getWorkoutFromIndexNum(index + 1);
+            System.out.println(index + 1 + ". " + workoutObject.toString());
             index += 1;
         }
         return index;
@@ -195,8 +226,10 @@ public class WorkoutList {
         }
 
         assert (indexToDelete > 0) && (indexToDelete <= workoutsDisplayList.size());
-        Workout deletedWorkout = workoutsDisplayList.get(indexToDelete - 1);
+        Workout deletedWorkout = getWorkoutFromIndexNum(indexToDelete);
         workoutsDisplayList.remove(indexToDelete - 1);
+        String deletedWorkoutKey = deletedWorkout.toString();
+        getWorkoutsHashMapList().remove(deletedWorkoutKey);
         logger.exiting(getClass().getName(), "deleteWorkout");
         return deletedWorkout;
     }
@@ -247,7 +280,7 @@ public class WorkoutList {
             throw new InvalidWorkoutException(className, InvalidWorkoutException.INVALID_REPS_VALUE_ERROR_MSG);
         }
 
-        Workout updatedWorkout = workoutsDisplayList.get(indexToUpdate - 1);
+        Workout updatedWorkout = getWorkoutFromIndexNum(indexToUpdate);
         String exerciseName = updatedWorkout.getExerciseName();
         boolean isExistingWorkout = checkForExistingWorkout(exerciseName, newRepsValue);
 
@@ -274,7 +307,8 @@ public class WorkoutList {
      *         Otherwise, returns false.
      */
     public boolean checkForExistingWorkout(String exerciseName, int repetitionCount) {
-        for (Workout existingWorkout : getWorkoutsDisplayList()) {
+        for (String existingWorkoutKey : getWorkoutsDisplayList()) {
+            Workout existingWorkout = getWorkoutsHashMapList().get(existingWorkoutKey);
             boolean hasSameExerciseName = existingWorkout.getExerciseName().equals(exerciseName);
             boolean hasSameRepsCount = (existingWorkout.getRepetitions() == repetitionCount);
 

--- a/src/main/java/data/workouts/WorkoutList.java
+++ b/src/main/java/data/workouts/WorkoutList.java
@@ -5,6 +5,7 @@ import data.exercises.ExerciseList;
 import data.exercises.InvalidExerciseException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Scanner;
 import java.util.logging.Logger;
 import java.util.logging.Level;
@@ -18,7 +19,8 @@ public class WorkoutList {
     public static final int MAX_DISPLAY = 10;
 
     private ExerciseList exerciseList;
-    private ArrayList<Workout> workoutsList = new ArrayList<>();
+    private HashMap<String, Workout> workoutsList = new HashMap<>();
+    private ArrayList<Workout> workoutsDisplayList = new ArrayList<>();
     private static Logger logger = Logger.getLogger(WorkoutList.class.getName());
 
     /**
@@ -35,8 +37,8 @@ public class WorkoutList {
      *
      * @return An ArrayList of Workouts.
      */
-    public ArrayList<Workout> getWorkoutsList() {
-        return this.workoutsList;
+    public ArrayList<Workout> getWorkoutsDisplayList() {
+        return this.workoutsDisplayList;
     }
 
     /**
@@ -86,7 +88,7 @@ public class WorkoutList {
         Workout newWorkout = new Workout(userExerciseInput, userRepsInput);
         logger.log(Level.INFO, "New workout created.");
 
-        workoutsList.add(newWorkout);
+        workoutsDisplayList.add(newWorkout);
 
         return newWorkout;
     }
@@ -109,12 +111,12 @@ public class WorkoutList {
     public void listWorkout() {
         logger.entering(getClass().getName(), "listWorkout");
         int index = 0;
-        int totalPrints = workoutsList.size();
+        int totalPrints = workoutsDisplayList.size();
         String input = "";
 
         while (totalPrints > MAX_DISPLAY) {
             index = continuousPrinting(index, 10);
-            assert (index <= workoutsList.size());
+            assert (index <= workoutsDisplayList.size());
             totalPrints -= 10;
             while (!isInputYesOrNo(input)) {
                 System.out.println("Do you want to view more workouts? [yes/no]");
@@ -132,7 +134,7 @@ public class WorkoutList {
             System.out.println("Showed all workouts in list");
             return;
         } else {
-            assert (workoutsList.size() == 0);
+            assert (workoutsDisplayList.size() == 0);
             System.out.println("The workout list is empty");
         }
         logger.exiting(getClass().getName(), "listWorkout");
@@ -143,10 +145,10 @@ public class WorkoutList {
      */
     public int continuousPrinting(int index, int noOfPrints) {
         System.out.println("Showing workouts " + (index + 1) + "-" + (index + noOfPrints)
-                + " of " + workoutsList.size() + ":");
-        assert (noOfPrints <= workoutsList.size());
+                + " of " + workoutsDisplayList.size() + ":");
+        assert (noOfPrints <= workoutsDisplayList.size());
         for (int i = 0; i < noOfPrints; i++) {
-            System.out.println(index + 1 + ". " + workoutsList.get(index));
+            System.out.println(index + 1 + ". " + workoutsDisplayList.get(index));
             index += 1;
         }
         return index;
@@ -192,9 +194,9 @@ public class WorkoutList {
             throw new WorkoutOutOfRangeException(className, WorkoutOutOfRangeException.INDEX_VALUE_OUT_OF_RANGE);
         }
 
-        assert (indexToDelete > 0) && (indexToDelete <= workoutsList.size());
-        Workout deletedWorkout = workoutsList.get(indexToDelete - 1);
-        workoutsList.remove(indexToDelete - 1);
+        assert (indexToDelete > 0) && (indexToDelete <= workoutsDisplayList.size());
+        Workout deletedWorkout = workoutsDisplayList.get(indexToDelete - 1);
+        workoutsDisplayList.remove(indexToDelete - 1);
         logger.exiting(getClass().getName(), "deleteWorkout");
         return deletedWorkout;
     }
@@ -207,7 +209,7 @@ public class WorkoutList {
      * @return true if index is within range, else false if out of range.
      */
     private boolean checkIndexIsWithinRange(int index) {
-        return index > 0 && index <= workoutsList.size();
+        return index > 0 && index <= workoutsDisplayList.size();
     }
 
     /**
@@ -245,7 +247,7 @@ public class WorkoutList {
             throw new InvalidWorkoutException(className, InvalidWorkoutException.INVALID_REPS_VALUE_ERROR_MSG);
         }
 
-        Workout updatedWorkout = workoutsList.get(indexToUpdate - 1);
+        Workout updatedWorkout = workoutsDisplayList.get(indexToUpdate - 1);
         String exerciseName = updatedWorkout.getExerciseName();
         boolean isExistingWorkout = checkForExistingWorkout(exerciseName, newRepsValue);
 
@@ -272,7 +274,7 @@ public class WorkoutList {
      *         Otherwise, returns false.
      */
     public boolean checkForExistingWorkout(String exerciseName, int repetitionCount) {
-        for (Workout existingWorkout : getWorkoutsList()) {
+        for (Workout existingWorkout : getWorkoutsDisplayList()) {
             boolean hasSameExerciseName = existingWorkout.getExerciseName().equals(exerciseName);
             boolean hasSameRepsCount = (existingWorkout.getRepetitions() == repetitionCount);
 

--- a/src/main/java/data/workouts/WorkoutList.java
+++ b/src/main/java/data/workouts/WorkoutList.java
@@ -330,11 +330,10 @@ public class WorkoutList {
 
         assert (isIndexToUpdateValid && isNewRepsValueValid && !isExistingWorkout);
         String oldWorkoutKey = workoutToUpdate.toString();
-        Workout updatedWorkout = workoutToUpdate;
-        updatedWorkout.setRepetitions(newRepsValue);
-        updateWorkoutsHashMapList(oldWorkoutKey, updatedWorkout);
+        workoutToUpdate.setRepetitions(newRepsValue);
+        updateWorkoutsHashMapList(oldWorkoutKey, workoutToUpdate);
         logger.exiting(getClass().getName(), "Finished updating workout.");
-        return updatedWorkout;
+        return workoutToUpdate;
     }
 
     /**

--- a/src/main/java/data/workouts/WorkoutList.java
+++ b/src/main/java/data/workouts/WorkoutList.java
@@ -51,6 +51,16 @@ public class WorkoutList {
     }
 
     /**
+     * Gets the Workout object based on its key as stored in the workoutsHashMapList.
+     *
+     * @param workoutKey The key that maps to the desired Workout object.
+     * @return The Workout object that is mapped to workoutKey.
+     */
+    public Workout getWorkoutFromKey(String workoutKey) {
+        return getWorkoutsHashMapList().get(workoutKey);
+    }
+
+    /**
      * Retrieves the Workout object from the HashMap workoutsHashMapList based on the index number
      * of the object stored in workoutsDisplayList. This index number is the number shown in
      * 'workout /list'.
@@ -64,6 +74,34 @@ public class WorkoutList {
         String keyValue = getWorkoutsDisplayList().get(elementNum);
         Workout workoutObject = workoutsHashMapList.get(keyValue);
         return workoutObject;
+    }
+
+    /**
+     * Updates an existing Workout object in workoutsHashMapList's with a new key. This should be called when
+     * a workout's repetition count has been updated. Once the Workout object has been reassigned to the new
+     * key, the former key will be removed. The ArrayList workoutsDisplayList will also be updated with the
+     * new key.
+     *
+     * @param existingKey    The existing key that maps to the updated Workout object.
+     * @param updatedWorkout The Workout object that has been updated.
+     */
+    public void updateWorkoutsHashMapList(String existingKey, Workout updatedWorkout) {
+        // Update key-value in workoutHashMapList
+        String newKey = updatedWorkout.toString();
+        getWorkoutsHashMapList().put(newKey, updatedWorkout);
+        getWorkoutsHashMapList().remove(existingKey);
+
+        // Update key in workoutsDisplayList
+        for (int i = 0; i < getWorkoutsDisplayList().size(); i += 1) {
+            String key = getWorkoutsDisplayList().get(i);
+            if (key.equals(existingKey)) {
+                getWorkoutsDisplayList().set(i, newKey);
+                break;
+            }
+        }
+
+        assert (!getWorkoutsDisplayList().contains(existingKey)) : "Old key should no longer "
+                + "exist in workoutsDisplayList.";
     }
 
     /**
@@ -291,7 +329,9 @@ public class WorkoutList {
         }
 
         assert (isIndexToUpdateValid && isNewRepsValueValid && !isExistingWorkout);
+        String oldWorkoutKey = updatedWorkout.toString();
         updatedWorkout.setRepetitions(newRepsValue);
+        updateWorkoutsHashMapList(oldWorkoutKey, updatedWorkout);
         logger.exiting(getClass().getName(), "updateWorkout");
         return updatedWorkout;
     }

--- a/src/main/java/storage/FileManager.java
+++ b/src/main/java/storage/FileManager.java
@@ -398,7 +398,8 @@ public class FileManager {
 
         FileWriter fileWriter = new FileWriter(getWorkoutFilePath().toString());
         for (String workoutKey : listOfWorkouts) {
-            Workout workoutObject = workoutList.getWorkoutsHashMapList().get(workoutKey);
+            Workout workoutObject = workoutList.getWorkoutFromKey(workoutKey);
+            assert (workoutObject != null) : "Workout object is NULL";
             String workoutInFileFormat = convertWorkoutToFileDataFormat(workoutObject);
             fileWriter.append(workoutInFileFormat);
             fileWriter.append(System.lineSeparator());

--- a/src/main/java/storage/FileManager.java
+++ b/src/main/java/storage/FileManager.java
@@ -394,7 +394,7 @@ public class FileManager {
      *                              by this method.
      */
     public void rewriteAllWorkoutsToFile(WorkoutList workoutList) throws IOException, NullPointerException {
-        ArrayList<Workout> listOfWorkouts = workoutList.getWorkoutsList();
+        ArrayList<Workout> listOfWorkouts = workoutList.getWorkoutsDisplayList();
 
         FileWriter fileWriter = new FileWriter(getWorkoutFilePath().toString());
         for (Workout workout : listOfWorkouts) {

--- a/src/main/java/storage/FileManager.java
+++ b/src/main/java/storage/FileManager.java
@@ -394,11 +394,12 @@ public class FileManager {
      *                              by this method.
      */
     public void rewriteAllWorkoutsToFile(WorkoutList workoutList) throws IOException, NullPointerException {
-        ArrayList<Workout> listOfWorkouts = workoutList.getWorkoutsDisplayList();
+        ArrayList<String> listOfWorkouts = workoutList.getWorkoutsDisplayList();
 
         FileWriter fileWriter = new FileWriter(getWorkoutFilePath().toString());
-        for (Workout workout : listOfWorkouts) {
-            String workoutInFileFormat = convertWorkoutToFileDataFormat(workout);
+        for (String workoutKey : listOfWorkouts) {
+            Workout workoutObject = workoutList.getWorkoutsHashMapList().get(workoutKey);
+            String workoutInFileFormat = convertWorkoutToFileDataFormat(workoutObject);
             fileWriter.append(workoutInFileFormat);
             fileWriter.append(System.lineSeparator());
         }

--- a/src/test/java/data/workouts/WorkoutListTest.java
+++ b/src/test/java/data/workouts/WorkoutListTest.java
@@ -72,9 +72,9 @@ class WorkoutListTest {
 
         int workoutNumberToDeleteInList = 2;
 
-        assertEquals("sit up (15 reps)", wl.getWorkoutsList().get(workoutNumberToDeleteInList - 1).toString());
+        assertEquals("sit up (15 reps)", wl.getWorkoutsDisplayList().get(workoutNumberToDeleteInList - 1).toString());
         wl.deleteWorkout(Integer.toString(workoutNumberToDeleteInList));
-        assertEquals("lunge (10 reps)", wl.getWorkoutsList().get(workoutNumberToDeleteInList - 1).toString());
+        assertEquals("lunge (10 reps)", wl.getWorkoutsDisplayList().get(workoutNumberToDeleteInList - 1).toString());
     }
 
     @Test
@@ -116,11 +116,11 @@ class WorkoutListTest {
         int newReps = 15;
         String updateArgument = Integer.toString(indexToUpdate) + " " + Integer.toString(newReps);
 
-        String workoutDetails = wl.getWorkoutsList().get(indexToUpdate - 1).toString();
+        String workoutDetails = wl.getWorkoutsDisplayList().get(indexToUpdate - 1).toString();
 
         assertEquals("lunge (10 reps)", workoutDetails);
         wl.updateWorkout(updateArgument);
-        workoutDetails = wl.getWorkoutsList().get(indexToUpdate - 1).toString();
+        workoutDetails = wl.getWorkoutsDisplayList().get(indexToUpdate - 1).toString();
         assertEquals("lunge (15 reps)", workoutDetails);
     }
 


### PR DESCRIPTION
This PR contains an implementation to allow the WerkIt! application to be able to uniquely identify the various workouts without relying on relative indexes as displayed in `workout /list`. This will allow for a more robust system when plans and schedules are implemented.

Most of the new and updated methods are in `WorkoutList.java`, though there are some minor changes in `FileManager.java` too.

To keep it simple, the key used for the HashMap storing the `Workout` objects is based on the string representation of the Workout objects themselves, since the workout's exercise name + repetitions must be unique.

In addition, the following changes are implemented:
- In `build.gradle`, assertions have been enabled when running `./gradlew run` from the terminal.
- Modified `workout /list` display to include more empty lines to separate the status messages from the actual list.