### PR TITLE
Enhance functionality of plan /create

### DIFF
--- a/src/main/java/data/plans/PlanList.java
+++ b/src/main/java/data/plans/PlanList.java
@@ -72,7 +72,7 @@ public class PlanList {
 
         ArrayList<Workout> workoutsToAddInAPlanList = new ArrayList<Workout>();
         for (int i = 0; i < numberOfWorkoutsInAPlan; i += 1) {
-            int workoutNumberInteger = Integer.parseInt(userWorkoutNumbersString.split(",")[i]);
+            int workoutNumberInteger = Integer.parseInt(userWorkoutNumbersString.split(",")[i].trim());
 
             boolean isWithinWorkoutListRange = checkWorkoutNumberWithinRange(workoutNumberInteger);
             if (!isWithinWorkoutListRange) {

--- a/src/test/java/data/plans/PlanListTest.java
+++ b/src/test/java/data/plans/PlanListTest.java
@@ -64,6 +64,8 @@ class PlanListTest {
     void createAndAddPlan_validPlansAdded_expectValidPlans() throws InvalidPlanException {
         planList.createAndAddPlan("Plan 1 /workouts 1,5,4,3");
         planList.createAndAddPlan("Plan 2 /workouts 1,5,4,3,1,1,1");
+        planList.createAndAddPlan("Plan 3 /workouts 1, 3, 4");
+        planList.createAndAddPlan("Plan 4 /workouts 1,1, 5,2");
 
         for (int i = 0; i < planList.getPlansDisplayList().size(); i += 1) {
             assertEquals("Plan " + (i + 1), planList.getPlansDisplayList().get(i).toString());

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -116,6 +116,7 @@ class ParserTest {
     void createPlanCommand_validPlanCommand_expectSuccess() throws InvalidCommandException {
         assertTrue(parser.createPlanCommand("plan /new Random /workouts 1,2,3") instanceof PlanCommand);
         assertTrue(parser.createPlanCommand("plan /new Random /workouts 1,1,1,1,1,1,1,1,1,1") instanceof PlanCommand);
+        assertTrue(parser.createPlanCommand("plan /new Random /workouts 1, 3, 2") instanceof PlanCommand);
         assertTrue(parser.createPlanCommand("plan /new Random /workouts 2") instanceof PlanCommand);
         assertTrue(parser.createPlanCommand("plan /list") instanceof PlanCommand);
     }


### PR DESCRIPTION
Addresses issue #111 . Now users can add whitespaces between commas when they specify the workouts to be added in their plan creation. Additionally, additional test cases have been added.