### PR TITLE
DeveloperGuide.md: Fix broken code block

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -34,6 +34,7 @@ with this IDE.
 [here](https://www.jetbrains.com/help/idea/sdk.html#set-up-jdk).
 4. Run `Main.java`. If you have set up your environment correctly, you should see the following
 output in your terminal: 
+
 ```
 ======================================================================
  __        __        _    ___ _   _ 
@@ -73,6 +74,7 @@ Now then, what can I do for you today?
 ----------------------------------------------------------------------
 >
 ```
+
 5. Type `exit` to exit the program.
 
 You are now ready to begin developing!


### PR DESCRIPTION
This PR is a hotfix to a bug in the developer guide when viewed with GitHub Pages where one of the code blocks are not displayed correctly.

Screenshot of the issue when viewed with GitHub Pages:
![image](https://user-images.githubusercontent.com/30099983/159905859-eb010046-1705-4906-9fe9-c1d32dfd6ab0.png)
