### PR TITLE
Fix bug related to an issue with loading of schedule data from file

### DIFF
--- a/src/main/java/data/plans/InvalidPlanException.java
+++ b/src/main/java/data/plans/InvalidPlanException.java
@@ -6,6 +6,7 @@ package data.plans;
 public class InvalidPlanException extends Exception {
     // Pre-defined error messages
     public static final String INVALID_PLAN_NAME_ERROR_MSG = "Uh oh, the plan name is invalid.";
+    public static final String UNKNOWN_PLAN_NAME_ERROR_MSG = "Uh oh, the plan name given does not exist.";
     public static final String WORKOUT_NUMBER_OUT_OF_RANGE = "Uh oh, the index specified is out of range.\n"
             + "(Index specified needs to be within the number of workouts)";
     public static final String MIN_MAX_WORKOUTS_IN_A_PLAN = "Uh oh, number of workouts specified is out of range.\n"

--- a/src/main/java/data/plans/PlanList.java
+++ b/src/main/java/data/plans/PlanList.java
@@ -82,6 +82,26 @@ public class PlanList {
     }
 
     /**
+     * Retrieves the index number of a plan based on its position in the plansDisplayList
+     * ArrayList.
+     *
+     * @param planName The name of the plan whose index number this method has to find.
+     * @return An integer representing the index number the plan is listed in the plansDisplayList
+     *         ArrayList.
+     * @throws InvalidPlanException If the given plan name was not found in plansDisplayList.
+     */
+    public int getIndexNumFromPlanName(String planName) throws InvalidPlanException {
+        for (int i = 0; i < getPlansDisplayList().size(); i += 1) {
+            if (getPlansDisplayList().get(i).equals(planName)) {
+                return (i + 1);
+            }
+        }
+
+        String className = this.getClass().getSimpleName();
+        throw new InvalidPlanException(className, InvalidPlanException.UNKNOWN_PLAN_NAME_ERROR_MSG);
+    }
+
+    /**
      * Parses the given user argument to identify the details of the new plan to be added.
      * Thereafter, the details will be checked for their validity. If all checks pass, a new
      * Plan object is instantiated before adding it to the ArrayList of plans.

--- a/src/main/java/storage/FileManager.java
+++ b/src/main/java/storage/FileManager.java
@@ -3,6 +3,7 @@ package storage;
 import commands.WorkoutCommand;
 import data.exercises.ExerciseList;
 import data.exercises.InvalidExerciseException;
+import data.plans.InvalidPlanException;
 import data.plans.Plan;
 import data.plans.PlanList;
 import data.schedule.Day;
@@ -61,19 +62,23 @@ public class FileManager {
     private boolean wasPlansFileAlreadyMade = false;
     private boolean wasScheduleFileAlreadyMade = false;
 
+    private PlanList planList;
+
     private static Logger logger = Logger.getLogger(FileManager.class.getName());
 
     /**
      * Constructs a FileManager object. While instantiating, Paths objects of the various URIs
      * are also instantiated.
      */
-    public FileManager() {
+    public FileManager(PlanList planList) {
         String workingDirectory = System.getProperty(USER_WORKING_DIRECTORY_PROPERTY);
         this.directoryPath = Paths.get(workingDirectory, DATA_DIRECTORY_NAME);
         this.exerciseFilePath = Paths.get(workingDirectory, DATA_DIRECTORY_NAME, EXERCISE_FILENAME);
         this.workoutFilePath = Paths.get(workingDirectory, DATA_DIRECTORY_NAME, WORKOUT_FILENAME);
         this.planFilePath = Paths.get(workingDirectory, DATA_DIRECTORY_NAME, PLAN_FILENAME);
         this.scheduleFilePath = Paths.get(workingDirectory, DATA_DIRECTORY_NAME, SCHEDULE_FILENAME);
+
+        this.planList = planList;
 
         LogHandler.linkToFileLogger(logger);
     }
@@ -207,6 +212,15 @@ public class FileManager {
      */
     public void setWasScheduleFileAlreadyMade(boolean wasScheduleFileAlreadyMade) {
         this.wasScheduleFileAlreadyMade = wasScheduleFileAlreadyMade;
+    }
+
+    /**
+     * Gets the PlanList object stored in this instance of FileManager.
+     *
+     * @return The PlanList object.
+     */
+    public PlanList getPlanList() {
+        return this.planList;
     }
 
     /**
@@ -462,7 +476,7 @@ public class FileManager {
             } catch (ArrayIndexOutOfBoundsException e) {
                 System.out.println("File data error: insufficient parameters in plan data.");
                 hasNoErrorsDuringLoad = false;
-            } catch (InvalidScheduleException e) {
+            } catch (InvalidScheduleException | InvalidPlanException e) {
                 System.out.println("File data error: " + e.getMessage());
                 hasNoErrorsDuringLoad = false;
             }
@@ -485,6 +499,11 @@ public class FileManager {
      */
     public String[] parseFileDataLine(String fileDataLine) {
         String[] parsedFileDataLine = fileDataLine.split(FILE_DATA_DELIMITER_REGEX);
+
+        for (int i = 0; i < parsedFileDataLine.length; i += 1) {
+            parsedFileDataLine[i] = parsedFileDataLine[i].trim();
+        }
+
         return parsedFileDataLine;
     }
 
@@ -531,13 +550,15 @@ public class FileManager {
      * @param scheduleFileDataLine An array of the parsed day schedule data read from the resource file.
      * @throws ArrayIndexOutOfBoundsException If the parsed data contains insufficient information.
      * @throws InvalidScheduleException       If the parsed data contains invalid day schedule data or format.
+     * @throws InvalidPlanException           If the plan name could not be found in this session's list of plans.
      */
     public void addFileScheduleToList(DayList dayList, String[] scheduleFileDataLine)
-            throws ArrayIndexOutOfBoundsException, InvalidScheduleException {
+            throws ArrayIndexOutOfBoundsException, InvalidScheduleException, InvalidPlanException {
         String dayNumber = scheduleFileDataLine[0];
         String planName = scheduleFileDataLine[1];
+        int planNameIndexNum = getPlanList().getIndexNumFromPlanName(planName);
 
-        String userArguments = dayNumber + " " + planName;
+        String userArguments = dayNumber + " " + planNameIndexNum;
         dayList.updateDay(userArguments);
     }
 

--- a/src/main/java/werkit/WerkIt.java
+++ b/src/main/java/werkit/WerkIt.java
@@ -40,8 +40,8 @@ public class WerkIt {
         this.ui = new UI();
         this.exerciseList = new ExerciseList();
         this.workoutList = new WorkoutList(getExerciseList());
-        this.fileManager = new FileManager();
         this.planList = new PlanList(getWorkoutList());
+        this.fileManager = new FileManager(getPlanList());
         this.dayList = new DayList(getPlanList());
         this.parser = new Parser(getUI(), getExerciseList(), getWorkoutList(),
                 getFileManager(), getPlanList(), getDayList());

--- a/src/test/java/commands/WorkoutCommandTest.java
+++ b/src/test/java/commands/WorkoutCommandTest.java
@@ -1,6 +1,7 @@
 package commands;
 
 import data.exercises.ExerciseList;
+import data.plans.PlanList;
 import data.workouts.WorkoutList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,11 @@ public class WorkoutCommandTest {
         String userInput = "workout /new russian twist /reps 1000";
         String userAction = "/new";
         String userArguments = "russian twist /reps 1000";
-        FileManager fm = new FileManager();
         ExerciseList el = new ExerciseList();
         WorkoutList wl = new WorkoutList(el);
+        PlanList pl = new PlanList(wl);
+        FileManager fm = new FileManager(pl);
+
 
         WorkoutCommand commandTest = new WorkoutCommand(userInput, fm, wl, userAction, userArguments);
 
@@ -45,9 +48,10 @@ public class WorkoutCommandTest {
         String userAction2 = "/create";
         String userArguments2 = "running /reps 20";
 
-        FileManager fm = new FileManager();
         ExerciseList el = new ExerciseList();
         WorkoutList wl = new WorkoutList(el);
+        PlanList pl = new PlanList(wl);
+        FileManager fm = new FileManager(pl);
 
         assertThrows(InvalidCommandException.class,
             () -> new WorkoutCommand(userInput1, fm, wl, userAction1, userArguments1));

--- a/src/test/java/storage/FileManagerTest.java
+++ b/src/test/java/storage/FileManagerTest.java
@@ -1,7 +1,10 @@
 package storage;
 
+import data.exercises.ExerciseList;
+import data.plans.PlanList;
 import data.workouts.Workout;
 import data.plans.Plan;
+import data.workouts.WorkoutList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,10 +14,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FileManagerTest {
+    ExerciseList el;
+    WorkoutList wl;
+    PlanList pl;
 
     @BeforeEach
     public void setUp() {
         LogHandler.startLogHandler();
+        el = new ExerciseList();
+        wl = new WorkoutList(el);
+        pl = new PlanList(wl);
     }
 
     @Test
@@ -27,7 +36,7 @@ public class FileManagerTest {
         String expectedOutput2 = "russian twist | 1000";
         String expectedOutput3 = "swimming | 20";
 
-        FileManager fm = new FileManager();
+        FileManager fm = new FileManager(pl);
 
         assertEquals(expectedOutput1, fm.convertWorkoutToFileDataFormat(testWorkoutSample1));
         assertEquals(expectedOutput2, fm.convertWorkoutToFileDataFormat(testWorkoutSample2));
@@ -50,7 +59,7 @@ public class FileManagerTest {
         Plan testPlanSample2 = new Plan("hotMan", listOfWorkouts2);
         String expectedOutput1 = "coolMan | push up | 1,russian twist | 1000,swimming | 20";
         String expectedOutput2 = "hotMan | push up | 1,swimming | 20";
-        FileManager fm = new FileManager();
+        FileManager fm = new FileManager(pl);
 
         assertEquals(expectedOutput1, fm.convertPlanToFileDataFormat(testPlanSample1));
         assertEquals(expectedOutput2, fm.convertPlanToFileDataFormat(testPlanSample2));
@@ -60,7 +69,7 @@ public class FileManagerTest {
     public void convertWorkoutToFileDataFormat_nullWorkoutInput_exceptionThrown() {
         Workout testWorkoutSample1 = null;
 
-        FileManager fm = new FileManager();
+        FileManager fm = new FileManager(pl);
 
         assertThrows(NullPointerException.class,
             () -> fm.convertWorkoutToFileDataFormat(testWorkoutSample1));
@@ -70,7 +79,7 @@ public class FileManagerTest {
     public void convertPlanToFileDataFormat_nullPlanInput_exceptionThrown() {
         Plan testPlanSample1 = null;
 
-        FileManager fm = new FileManager();
+        FileManager fm = new FileManager(pl);
 
         assertThrows(NullPointerException.class,
             () -> fm.convertPlanToFileDataFormat(testPlanSample1));


### PR DESCRIPTION
This PR contains a bug fix that resolves an issue where the plans cannot be read from `schedule.txt` when the app launches.

Upon analysis, it is discovered that in the `FileManager#addFileScheduleToList(...)` method, `PlanList#createAndAddPlan(...)` is invoked with parameters `<day number> <plan name>`. However, the correct parameter to use is `<day number> <index number of plan name>`. This index number is the positioning of the plan as stored in the `plansDisplayList` in `PlanList.java`.

As a result, the following changes/fixes have been implemented:
- [`PlanList.java`] Created a new method to retrieve the index number of a specified plan name (based on the plan's positioning in the `plansDisplayList` ArrayList.
- [`FileManager#addFileScheduleToList(...)`] Instead of calling `PlanList#createAndAddPlan(...)` with plan name as part of the argument, the index number of the plan will be used instead.
- [`FileManager.java`] As this class now requires the instance of `PlanList`, its constructor will now take in one parameter, which is the instance of `PlanList`.
- Other places in the application code, as well as test cases, have been updated to match the new signature of the `FileManager` class constructor.