### PR TITLE
Add check for creating plan with the same sequence

### DIFF
--- a/src/main/java/data/plans/InvalidPlanException.java
+++ b/src/main/java/data/plans/InvalidPlanException.java
@@ -13,8 +13,8 @@ public class InvalidPlanException extends Exception {
             + "(A plan should minimally have 1 workout and 10 workouts at most.)";
     public static final String PLAN_INDEX_OUT_OF_RANGE = "Uh oh, the index specified is out of range.\n"
             + "(Index specified needs to be within the number of plans)";
-    public static final String PLAN_SAME_WORKOUT_SEQUENCE = "The plan to create is invalid as an\n"
-            + "existing plan with the same workout sequence exists.";
+    public static final String PLAN_SAME_WORKOUT_SEQUENCE = "Uh oh, an existing plan with the same\n"
+            + "workout sequence already exists.";
 
     private String throwingClass;
 

--- a/src/main/java/data/plans/InvalidPlanException.java
+++ b/src/main/java/data/plans/InvalidPlanException.java
@@ -13,6 +13,8 @@ public class InvalidPlanException extends Exception {
             + "(A plan should minimally have 1 workout and 10 workouts at most.)";
     public static final String PLAN_INDEX_OUT_OF_RANGE = "Uh oh, the index specified is out of range.\n"
             + "(Index specified needs to be within the number of plans)";
+    public static final String PLAN_SAME_WORKOUT_SEQUENCE = "The plan to create is invalid as an\n"
+            + "existing plan with the same workout sequence exists.";
 
     private String throwingClass;
 

--- a/src/main/java/data/plans/PlanList.java
+++ b/src/main/java/data/plans/PlanList.java
@@ -123,7 +123,7 @@ public class PlanList {
 
         int numberOfWorkoutsInAPlan = userWorkoutNumbersString.split(",").length;
         checkMinMaxNumberOfWorkouts(numberOfWorkoutsInAPlan, className);
-        assert (numberOfWorkoutsInAPlan > 0 && numberOfWorkoutsInAPlan <= MAX_NUMBER_OF_WORKOUTS_IN_A_PLAN);
+        assert (numberOfWorkoutsInAPlan > 0) && (numberOfWorkoutsInAPlan <= MAX_NUMBER_OF_WORKOUTS_IN_A_PLAN);
 
         ArrayList<Workout> workoutsToAddInAPlanList = new ArrayList<Workout>();
         for (int i = 0; i < numberOfWorkoutsInAPlan; i += 1) {

--- a/src/test/java/data/plans/PlanListTest.java
+++ b/src/test/java/data/plans/PlanListTest.java
@@ -114,4 +114,11 @@ class PlanListTest {
             () -> planList.createAndAddPlan("Plan 2 /workouts 9"));
     }
 
+    @Test
+    void createAndAddPlan_workoutWithSameSequence_expectInvalidPlanException() throws InvalidPlanException {
+        planList.createAndAddPlan("Plan 1 /workouts 1,2,3");
+        assertThrows(InvalidPlanException.class,
+            () -> planList.createAndAddPlan("Duplicate Sequence /workouts 1,2,3"));
+    }
+
 }


### PR DESCRIPTION
The following PR is made to improve further the create plan function.
Basically, no two plans can have the same workout sequence e.g.
[Plan A: 1,1,1]
[Plan B: 1,1,1]

Additionally, improved SLAP for the create plan function.
