### PR TITLE
Improve create plan name validity checking

### DIFF
--- a/src/main/java/data/plans/InvalidPlanException.java
+++ b/src/main/java/data/plans/InvalidPlanException.java
@@ -5,7 +5,7 @@ package data.plans;
  */
 public class InvalidPlanException extends Exception {
     // Pre-defined error messages
-    public static final String INVALID_PLAN_NAME_ERROR_MSG = "Uh oh, the plan name is invalid.";
+    public static final String DUPLICATE_PLAN_NAME_ERROR_MSG = "Uh oh, the plan name already exists.";
     public static final String UNKNOWN_PLAN_NAME_ERROR_MSG = "Uh oh, the plan name given does not exist.";
     public static final String WORKOUT_NUMBER_OUT_OF_RANGE = "Uh oh, the index specified is out of range.\n"
             + "(Index specified needs to be within the number of workouts)";
@@ -15,6 +15,9 @@ public class InvalidPlanException extends Exception {
             + "(Index specified needs to be within the number of plans)";
     public static final String PLAN_SAME_WORKOUT_SEQUENCE = "Uh oh, an existing plan with the same\n"
             + "workout sequence already exists.";
+    public static final String PLAN_NAME_EXCEED_LIMIT = "Uh oh, the plan name exceeds the character limit (30).";
+    public static final String PLAN_NAME_WHITESPACES_ONLY = "Uh oh, the plan name cannot contain whitespaces only.";
+    public static final String RESERVED_PLAN_NAME = "Uh oh, this plan name is reserved for use.";
 
     private String throwingClass;
 

--- a/src/main/java/data/plans/PlanList.java
+++ b/src/main/java/data/plans/PlanList.java
@@ -21,6 +21,7 @@ import java.util.logging.Logger;
 public class PlanList {
     public static final int MAX_NUMBER_OF_WORKOUTS_IN_A_PLAN = 10;
     public static final String RESERVED_PLAN_NAME = "rest day";
+    public static final int PLAN_NAME_CHARACTER_LIMIT = 30;
     private WorkoutList workoutList;
     private HashMap<String, Plan> plansHashMapList = new HashMap<>();
     private ArrayList<String> plansDisplayList = new ArrayList<>();
@@ -148,10 +149,10 @@ public class PlanList {
     }
 
     /**
-     * Checks if the provided plan details already exists in the ArrayList of plans. A plan
-     * is considered to already exist in the list if the plan name matches an existing plan
-     * name in the ArrayList. Additionally, checks if the plan name is called "rest day".
-     * If it is, do not allow a plan called "rest day" as it is used in the schedule feature.
+     * Checks if the plan name exceeds the 30 characters limit, if it only consists of
+     * whitespaces and also checks if the provided plan name already exists in the ArrayList of plans.
+     * Additionally, checks if the plan name is called "rest day". If it is,
+     * do not allow a plan called "rest day" to be created as it is used in the schedule feature.
      *
      * @param userPlanNameInput The plan name entered by user to check.
      * @param className The class name used for exception throwing.
@@ -159,24 +160,31 @@ public class PlanList {
      */
     public void checkPlanNameValidity(String userPlanNameInput, String className) throws
             InvalidPlanException {
-        boolean hasValidPlanName = true;
         String userPlanNameInputLowerCase = userPlanNameInput.toLowerCase();
+
+        int characterCount = userPlanNameInput.length();
+        if (characterCount > PLAN_NAME_CHARACTER_LIMIT) {
+            logger.log(Level.WARNING, "Plan name exceeds character limit.");
+            throw new InvalidPlanException(className, InvalidPlanException.PLAN_NAME_EXCEED_LIMIT);
+        }
+
+        if (userPlanNameInput.trim().equals("")) {
+            logger.log(Level.WARNING, "Plan name is just whitespaces.");
+            throw new InvalidPlanException(className, InvalidPlanException.PLAN_NAME_WHITESPACES_ONLY);
+        }
 
         for (int i = 0; i < plansDisplayList.size(); i += 1) {
             String getPlanName = plansDisplayList.get(i).toLowerCase();
 
             if (userPlanNameInputLowerCase.equals(getPlanName)) {
-                hasValidPlanName = false;
+                logger.log(Level.WARNING, "Plan name already exists.");
+                throw new InvalidPlanException(className, InvalidPlanException.DUPLICATE_PLAN_NAME_ERROR_MSG);
             }
         }
 
-        if (userPlanNameInputLowerCase.equals(RESERVED_PLAN_NAME)) {
-            hasValidPlanName = false;
-        }
-
-        if (!hasValidPlanName) {
-            logger.log(Level.WARNING, "Plan name is invalid.");
-            throw new InvalidPlanException(className, InvalidPlanException.INVALID_PLAN_NAME_ERROR_MSG);
+        if (userPlanNameInputLowerCase.trim().equals(RESERVED_PLAN_NAME)) {
+            logger.log(Level.WARNING, "Plan name cannot be 'rest day'.");
+            throw new InvalidPlanException(className, InvalidPlanException.RESERVED_PLAN_NAME);
         }
     }
 

--- a/src/test/java/data/plans/PlanListTest.java
+++ b/src/test/java/data/plans/PlanListTest.java
@@ -96,6 +96,12 @@ class PlanListTest {
             () -> planList.createAndAddPlan("Plan 1 /workouts 2,2,2"));
         assertThrows(InvalidPlanException.class,
             () -> planList.createAndAddPlan("rest day /workouts 3,2,3"));
+        assertThrows(InvalidPlanException.class,
+            () -> planList.createAndAddPlan("REST DAY       /workouts 3,2,3,1"));
+        assertThrows(InvalidPlanException.class,
+            () -> planList.createAndAddPlan("        /workouts 3,2,3,1,1"));
+        assertThrows(InvalidPlanException.class,
+            () -> planList.createAndAddPlan("Exceed the 30 characters limit yes /workouts 1,2,1"));
     }
 
     @Test


### PR DESCRIPTION
Additional checks for plan name is done:
1. Plan name does not exceed 30 characters
2. Plan name does not only contain whitespaces (e.g. a plan named "                ").