### PR TITLE
Create More JUnit Tests to Expand Test Coverage

### DIFF
--- a/src/main/java/werkit/WerkIt.java
+++ b/src/main/java/werkit/WerkIt.java
@@ -5,7 +5,6 @@ import commands.ExitCommand;
 import commands.InvalidCommandException;
 import data.exercises.ExerciseList;
 import data.plans.PlanList;
-import data.schedule.Day;
 import data.schedule.DayList;
 import data.workouts.WorkoutList;
 import storage.FileManager;

--- a/src/test/java/data/workouts/WorkoutListTest.java
+++ b/src/test/java/data/workouts/WorkoutListTest.java
@@ -9,7 +9,9 @@ import storage.LogHandler;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 class WorkoutListTest {
@@ -47,6 +49,30 @@ class WorkoutListTest {
         assertEquals(outputWorkout2.getExerciseName(), "crunch");
         assertEquals(outputWorkout2.getRepetitions(), 2359);
         assertTrue(wl.checkForExistingWorkout("crunch", 2359));
+    }
+
+    @Test
+    void createAndAddWorkout_invalidExerciseName_expectInvalidExcerciseException() {
+        String invalidWorkout = "weeeeeee /reps 500";
+        assertThrows(InvalidExerciseException.class, () -> wl.createAndAddWorkout(invalidWorkout));
+    }
+
+    @Test
+    void createAndAddWorkout_invalidRepCount_expectInvalidWorkoutException() {
+        String invalidWorkout1 = "push up /reps -12345";
+        assertThrows(InvalidWorkoutException.class, () -> wl.createAndAddWorkout(invalidWorkout1));
+
+        String invalidWorkout2 = "sit up /reps 0";
+        assertThrows(InvalidWorkoutException.class, () -> wl.createAndAddWorkout(invalidWorkout2));
+    }
+
+    @Test
+    void createAndAddWorkout_addExistingWorkout_expectInvalidWorkoutException() throws InvalidExerciseException,
+            InvalidWorkoutException {
+        String workout = "burpee /reps 100";
+        wl.createAndAddWorkout(workout);
+
+        assertThrows(InvalidWorkoutException.class, () -> wl.createAndAddWorkout(workout));
     }
 
     @Test

--- a/src/test/java/data/workouts/WorkoutListTest.java
+++ b/src/test/java/data/workouts/WorkoutListTest.java
@@ -9,8 +9,7 @@ import storage.LogHandler;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 class WorkoutListTest {
@@ -32,6 +31,22 @@ class WorkoutListTest {
         exerciseList.addExerciseToList("crunch");
         exerciseList.addExerciseToList("russian twist");
         exerciseList.addExerciseToList("jumping jack");
+    }
+
+    @Test
+    void createAndAddWorkout_normalCreation_expectSuccess() throws InvalidExerciseException,
+            InvalidWorkoutException {
+        String newWorkout1 = "russian twist /reps 1000";
+        Workout outputWorkout1 = wl.createAndAddWorkout(newWorkout1);
+        assertEquals(outputWorkout1.getExerciseName(), "russian twist");
+        assertEquals(outputWorkout1.getRepetitions(), 1000);
+        assertTrue(wl.checkForExistingWorkout("russian twist", 1000));
+
+        String newWorkout2 = "crunch /reps 2359";
+        Workout outputWorkout2 = wl.createAndAddWorkout(newWorkout2);
+        assertEquals(outputWorkout2.getExerciseName(), "crunch");
+        assertEquals(outputWorkout2.getRepetitions(), 2359);
+        assertTrue(wl.checkForExistingWorkout("crunch", 2359));
     }
 
     @Test

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -121,12 +121,14 @@ class ParserTest {
         assertTrue(parser.createWorkoutCommand("workout /update 1 15") instanceof WorkoutCommand);
         assertTrue(parser.createWorkoutCommand("workout /delete 1") instanceof WorkoutCommand);
         assertTrue(parser.createWorkoutCommand("workout /list") instanceof WorkoutCommand);
+        assertTrue(parser.createWorkoutCommand("workout /listall") instanceof WorkoutCommand);
     }
 
     @Test
     void createWorkoutCommand_invalidWorkoutCommand_exceptionThrown() {
         assertThrows(InvalidCommandException.class, () -> parser.createWorkoutCommand("workout /new"));
         assertThrows(InvalidCommandException.class, () -> parser.createWorkoutCommand("workout /list extra"));
+        assertThrows(InvalidCommandException.class, () -> parser.createWorkoutCommand("workout /listall hmm?"));
         assertThrows(InvalidCommandException.class, () -> parser.createWorkoutCommand("workout /delete"));
         assertThrows(InvalidCommandException.class, () -> parser.createWorkoutCommand("workout /update"));
         assertThrows(InvalidCommandException.class, () -> parser.createWorkoutCommand("workout /test"));

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -69,39 +69,45 @@ class ParserTest {
     @Test
     void parseUserInput_validSearchCommand_expectSuccess() throws InvalidCommandException {
         String searchCommand1 = "search /exercise up";
-        String searchCommand2 = "search /workout 1000";
-        String searchCommand3 = "search /plan biceps";
-        String searchCommand4 = "search /all weeee";
-
         assertTrue(parser.parseUserInput(searchCommand1) instanceof SearchCommand);
+
+        String searchCommand2 = "search /workout 1000";
         assertTrue(parser.parseUserInput(searchCommand2) instanceof SearchCommand);
+
+        String searchCommand3 = "search /plan biceps";
         assertTrue(parser.parseUserInput(searchCommand3) instanceof SearchCommand);
+
+        String searchCommand4 = "search /all weeee";
         assertTrue(parser.parseUserInput(searchCommand4) instanceof SearchCommand);
     }
 
     @Test
     void parseUserInput_validPlanCommand_expectSuccess() throws InvalidCommandException {
         String planCommand1 = "plan /new plan 1 /workouts 1, 2, 3, 4";
-        String planCommand2 = "plan /list";
-        String planCommand3 = "plan /details 1";
-        String planCommand4 = "plan /delete 1";
-
         assertTrue(parser.parseUserInput(planCommand1) instanceof PlanCommand);
+
+        String planCommand2 = "plan /list";
         assertTrue(parser.parseUserInput(planCommand2) instanceof PlanCommand);
+
+        String planCommand3 = "plan /details 1";
         assertTrue(parser.parseUserInput(planCommand3) instanceof PlanCommand);
+
+        String planCommand4 = "plan /delete 1";
         assertTrue(parser.parseUserInput(planCommand4) instanceof PlanCommand);
     }
 
     @Test
     void parseUserInput_validScheduleCommand_expectSuccess() throws InvalidCommandException {
         String scheduleCommand1 = "schedule /update 1 2";
-        String scheduleCommand2 = "schedule /list";
-        String scheduleCommand3 = "schedule /clear 1";
-        String scheduleCommand4 = "schedule /clearall";
-
         assertTrue(parser.parseUserInput(scheduleCommand1) instanceof ScheduleCommand);
+
+        String scheduleCommand2 = "schedule /list";
         assertTrue(parser.parseUserInput(scheduleCommand2) instanceof ScheduleCommand);
+
+        String scheduleCommand3 = "schedule /clear 1";
         assertTrue(parser.parseUserInput(scheduleCommand3) instanceof ScheduleCommand);
+
+        String scheduleCommand4 = "schedule /clearall";
         assertTrue(parser.parseUserInput(scheduleCommand4) instanceof ScheduleCommand);
     }
 

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -59,6 +59,13 @@ class ParserTest {
     }
 
     @Test
+    void parseUserInput_validExerciseCommand_expectSuccess() throws InvalidCommandException {
+        String exerciseCommand = "exercise /list";
+
+        assertTrue(parser.parseUserInput(exerciseCommand) instanceof ExerciseCommand);
+    }
+
+    @Test
     void parseUserInput_invalidGeneralCommand_exceptionThrown() {
         assertThrows(InvalidCommandException.class, () -> parser.parseUserInput("exitt"));
         assertThrows(InvalidCommandException.class, () -> parser.parseUserInput("helpp"));

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.Test;
 import storage.FileManager;
 import storage.LogHandler;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -80,7 +80,15 @@ class ParserTest {
 
     @Test
     void parseUserInput_validPlanCommand_expectSuccess() throws InvalidCommandException {
-        
+        String planCommand1 = "plan /new plan 1 /workouts 1, 2, 3, 4";
+        String planCommand2 = "plan /list";
+        String planCommand3 = "plan /details 1";
+        String planCommand4 = "plan /delete 1";
+
+        assertTrue(parser.parseUserInput(planCommand1) instanceof PlanCommand);
+        assertTrue(parser.parseUserInput(planCommand2) instanceof PlanCommand);
+        assertTrue(parser.parseUserInput(planCommand3) instanceof PlanCommand);
+        assertTrue(parser.parseUserInput(planCommand4) instanceof PlanCommand);
     }
 
     @Test

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -8,6 +8,7 @@ import commands.ExitCommand;
 import commands.HelpCommand;
 import commands.ExerciseCommand;
 import commands.PlanCommand;
+import commands.ScheduleCommand;
 import data.exercises.ExerciseList;
 import data.plans.PlanList;
 import data.schedule.DayList;
@@ -89,6 +90,19 @@ class ParserTest {
         assertTrue(parser.parseUserInput(planCommand2) instanceof PlanCommand);
         assertTrue(parser.parseUserInput(planCommand3) instanceof PlanCommand);
         assertTrue(parser.parseUserInput(planCommand4) instanceof PlanCommand);
+    }
+
+    @Test
+    void parseUserInput_validScheduleCommand_expectSuccess() throws InvalidCommandException {
+        String scheduleCommand1 = "schedule /update 1 2";
+        String scheduleCommand2 = "schedule /list";
+        String scheduleCommand3 = "schedule /clear 1";
+        String scheduleCommand4 = "schedule /clearall";
+
+        assertTrue(parser.parseUserInput(scheduleCommand1) instanceof ScheduleCommand);
+        assertTrue(parser.parseUserInput(scheduleCommand2) instanceof ScheduleCommand);
+        assertTrue(parser.parseUserInput(scheduleCommand3) instanceof ScheduleCommand);
+        assertTrue(parser.parseUserInput(scheduleCommand4) instanceof ScheduleCommand);
     }
 
     @Test

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -58,7 +58,7 @@ class ParserTest {
 
     //Workout tests
     @Test
-    void createWorkoutCommand_validWorkoutCommand_expectSuccess() throws InvalidCommandException, IOException {
+    void createWorkoutCommand_validWorkoutCommand_expectSuccess() throws InvalidCommandException {
         assertTrue(parser.createWorkoutCommand("workout /new push up /reps 20") instanceof WorkoutCommand);
         assertTrue(parser.createWorkoutCommand("workout /update 1 15") instanceof WorkoutCommand);
         assertTrue(parser.createWorkoutCommand("workout /delete 1") instanceof WorkoutCommand);
@@ -77,7 +77,7 @@ class ParserTest {
 
     //Search tests
     @Test
-    void createSearchCommand_validSearchCommand_expectSuccess() throws InvalidCommandException, IOException {
+    void createSearchCommand_validSearchCommand_expectSuccess() throws InvalidCommandException {
         assertTrue(parser.createSearchCommand("search /exercise up") instanceof SearchCommand);
         assertTrue(parser.createSearchCommand("search /exercise asdaskd") instanceof SearchCommand);
         assertTrue(parser.createSearchCommand("search /plan cool") instanceof SearchCommand);

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -38,12 +38,23 @@ class ParserTest {
     }
 
     @Test
-    void parseUserInput_validHelpCommand_expectSuccess() throws InvalidCommandException, IOException {
+    void parseUserInput_validWorkoutCommand_expectSuccess() throws InvalidCommandException {
+        String workoutCommand1 = "workout /new russian twist /reps 1000";
+        String workoutCommand2 = "workout /list";
+        String workoutCommand3 = "workout /delete 1";
+
+        assertTrue(parser.parseUserInput(workoutCommand1) instanceof WorkoutCommand);
+        assertTrue(parser.parseUserInput(workoutCommand2) instanceof WorkoutCommand);
+        assertTrue(parser.parseUserInput(workoutCommand3) instanceof WorkoutCommand);
+    }
+
+    @Test
+    void parseUserInput_validHelpCommand_expectSuccess() throws InvalidCommandException {
         assertTrue(parser.parseUserInput("help") instanceof HelpCommand);
     }
 
     @Test
-    void parseUserInput_validExitCommand_expectSuccess() throws InvalidCommandException, IOException {
+    void parseUserInput_validExitCommand_expectSuccess() throws InvalidCommandException {
         assertTrue(parser.parseUserInput("exit") instanceof ExitCommand);
     }
 

--- a/src/test/java/werkit/ParserTest.java
+++ b/src/test/java/werkit/ParserTest.java
@@ -66,6 +66,24 @@ class ParserTest {
     }
 
     @Test
+    void parseUserInput_validSearchCommand_expectSuccess() throws InvalidCommandException {
+        String searchCommand1 = "search /exercise up";
+        String searchCommand2 = "search /workout 1000";
+        String searchCommand3 = "search /plan biceps";
+        String searchCommand4 = "search /all weeee";
+
+        assertTrue(parser.parseUserInput(searchCommand1) instanceof SearchCommand);
+        assertTrue(parser.parseUserInput(searchCommand2) instanceof SearchCommand);
+        assertTrue(parser.parseUserInput(searchCommand3) instanceof SearchCommand);
+        assertTrue(parser.parseUserInput(searchCommand4) instanceof SearchCommand);
+    }
+
+    @Test
+    void parseUserInput_validPlanCommand_expectSuccess() throws InvalidCommandException {
+        
+    }
+
+    @Test
     void parseUserInput_invalidGeneralCommand_exceptionThrown() {
         assertThrows(InvalidCommandException.class, () -> parser.parseUserInput("exitt"));
         assertThrows(InvalidCommandException.class, () -> parser.parseUserInput("helpp"));

--- a/src/test/java/werkit/WerkItTest.java
+++ b/src/test/java/werkit/WerkItTest.java
@@ -1,12 +1,48 @@
 package werkit;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import storage.LogHandler;
+
+import java.io.*;
 
 class WerkItTest {
+    private static final InputStream DEFAULT_STDIN = System.in;
+
+    @AfterEach
+    void rollbackStdIn() {
+        System.setIn(DEFAULT_STDIN);
+    }
+
     @Test
-    public void sampleTest() {
-        assertTrue(true);
+    void startContinuousUserPrompt_simpleExit_expectSuccess() throws IOException {
+        String testCommand = "exit" + System.lineSeparator();
+        ByteArrayInputStream testByteData = new ByteArrayInputStream(testCommand.getBytes());
+        System.setIn(testByteData);
+
+        LogHandler.startLogHandler();
+        WerkIt werkIt = new WerkIt();
+
+        String expectedOutput = "----------------------------------------------------------------------"
+                + System.lineSeparator()
+                + "Now then, what can I do for you today?"
+                + System.lineSeparator()
+                + "(Need help? Type 'help' for a guide!)"
+                + System.lineSeparator()
+                + "----------------------------------------------------------------------"
+                + System.lineSeparator()
+                + "> ----------------------------------------------------------------------"
+                + System.lineSeparator()
+                + "Thank you for using WerkIt! See you again soon..."
+                + System.lineSeparator()
+                + "======================================================================"
+                + System.lineSeparator();
+        ByteArrayOutputStream actualOutput = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(actualOutput));
+
+        werkIt.startContinuousUserPrompt();
+        assertEquals(expectedOutput, actualOutput.toString());
     }
 }

--- a/src/test/java/werkit/WerkItTest.java
+++ b/src/test/java/werkit/WerkItTest.java
@@ -6,7 +6,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import storage.LogHandler;
 
-import java.io.*;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 class WerkItTest {
     private static final InputStream DEFAULT_STDIN = System.in;


### PR DESCRIPTION
This PR contains additional/updated JUnit tests to improve the coverage of our tests on the WerkIt! codebase.

Test cases include:
- `Parser#parseUserInput()` - Check if the various `Command` subclasses are created correctly
- Coverage for `workout /listall` command in `Parser.java`
- `WerkIt#startContinuousUserPrompt()` - A simple test
- `Workout#createAndAddWorkout()` - Normal creation, and invalid creations.