### PR TITLE
Make Changes to the UG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -27,7 +27,7 @@ Below are the icons and their meanings:
 <span class="box warning">:warning: **Warning**: Information that you may want to pay attention to in order to prevent 
 possible issues from arising when using the application.</span>
 
-<span class="box info">:receipt: **Note**: Additional information that may be useful for you.</span>
+<span class="box info">:memo: **Note**: Additional information that may be useful for you.</span>
 
 
 ## Acknowledgements
@@ -45,7 +45,7 @@ The following websites and codebases were referenced and adapted for our project
 - [X] An IDE of your choice, though IntelliJ IDEA is recommended as this project is developed
 with this IDE.
 
-<span class="box info">:receipt: IDE-related references in this developer guide IDE will be tailored for IntelliJ IDEA.</span>
+<span class="box info">:memo: IDE-related references in this developer guide IDE will be tailored for IntelliJ IDEA.</span>
 
 ### Setting Up
 1. Fork the [WerkIt! GitHub repository](https://github.com/AY2122S2-CS2113T-T09-2/tp).
@@ -193,7 +193,7 @@ the user's input as a `String` object to `WerkIt#startContinuousUserPrompt()`. T
 object that is a subclass of the `Command` class. If there is no issue with the formatting of the user's input,
 this subclass-of-`Command` object is returned to `WerkIt#startContinuousUserPrompt()`.
 
-<span class="box info">:receipt: A detailed implementation of the parsing and creation of subclass-of-`Command` 
+<span class="box info">:memo: A detailed implementation of the parsing and creation of subclass-of-`Command` 
 object process can be found in 
 '[Parsing User Input and Getting the Right Command](#parsing-user-input-and-getting-the-right-command)'.</span>
 
@@ -228,7 +228,7 @@ for subsequent prompts.
 
 ![Obtain and Parse User Input](uml/sequenceDiagrams/miscellaneous/images/obtainAndParseUserInput.png)
 
-<span class="box info">:receipt: To improve the readability of the sequence diagram, the construction of the respective
+<span class="box info">:memo: To improve the readability of the sequence diagram, the construction of the respective
 objects which are subclasses of the `Command` class between Steps 4 and 17 are not included in the diagram.</span>
 
 **(Steps 1 and 2)** When a user enters something into the terminal (when prompted), `UI#getUserInput()` will take in 
@@ -264,7 +264,7 @@ it is returned to `Parser#parseUserInput()`.
 
 **(Step 18)** The object created is then returned to `WerkIt#startContinuousUserInput()`.
 
-<span class="box info">:receipt: (About the sequence diagram) Strictly speaking, the object is returned right after whichever 
+<span class="box info">:memo: (About the sequence diagram) Strictly speaking, the object is returned right after whichever 
 'create command' method is invoked. However, to improve the readability of the diagram, only one return line is shown,
 since all alternate paths will return an object that is a subclass of the `Command` class.</span>
 
@@ -320,7 +320,7 @@ A summary of the general procedure of a new workout being inputted and stored in
 
 The following sequence diagram illustrates how the `workout /new` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that are deemed to be trivial 
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that are deemed to be trivial 
 have been removed from the sequence diagram. Some reference frames will be elaborated further 
 down this section. Reference frames that will not be elaborated on will be made known.</span>
 
@@ -329,7 +329,7 @@ down this section. Reference frames that will not be elaborated on will be made 
 **(Before Step 1)** The user's input (in this case will be a `workout /new` command) is obtained and parsed to obtain
 a `WorkoutCommand` object that contains the user's input.
 
-<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:memo: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
 ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1)** When `WorkoutCommand#execute()` is called, because this is a `workout /new` command, the method will call
@@ -338,7 +338,7 @@ a `WorkoutCommand` object that contains the user's input.
 The following sequence diagram is the detailed procedures for Step 2's `WorkoutList#createAndAddWorkout()`:
 ![createAndAddWorkout() Sequence Diagram (Part 1)](uml/sequenceDiagrams/workouts/images/CreateAndAddWorkout.png)
 
-<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, and 
+<span class="box info">:memo: To improve the diagram's readability, logging-related and input-checking method calls, and 
 exception throws in `WorkoutList#createAndAddWorkout()` have been omitted.</span> 
 
 **(Before Step 2.1)** Methods from the `String` and `Integer` classes are called to parse the
@@ -481,7 +481,7 @@ A summary of the general procedure of an existing workout being removed from Wer
 
 The following sequence diagram illustrates how the `workout /delete` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -490,7 +490,7 @@ The following sequence diagram illustrates how the `workout /delete` command wor
 **(Before Step 1)** The user's input (in this case will be a `workout /delete` command) is obtained and parsed to obtain
 a `WorkoutCommand` object that contains the user's input.
 
-<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:memo: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1)** When the `WorkoutCommand#execute()` method is called, it will identify
@@ -501,7 +501,7 @@ The following sequence diagram is the detailed procedure for Step 2's `WorkoutLi
 <br><br>
 ![Delete Workout Detailed Sequence Diagram](uml/sequenceDiagrams/workouts/images/deleteWorkout-Part2.png)
 
-<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
+<span class="box info">:memo: To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
  `WorkoutList#deleteWorkout()` have been omitted.</span>
 
 **(Steps 2.1 to 2.2)** The `Integer#parseInt()` method is called to parse the user argument parameter given to `WorkoutList#deleteWorkout(userArgument)`.
@@ -566,7 +566,7 @@ is as follows:<br><br>
 
 The following sequence diagram illustrates how the `workout /update` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial 
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial 
 have been removed from the sequence diagram. Some reference frames will be elaborated further down this section.</span>
 
 ![Update Workout Sequence Diagram](uml/sequenceDiagrams/workouts/images/updateWorkout-Part1.png)
@@ -574,7 +574,7 @@ have been removed from the sequence diagram. Some reference frames will be elabo
 **(Before Step 1)** The user's input (in this case will be a `workout /update` command) is obtained and parsed to obtain
 a `WorkoutCommand` object that contains the user's input.
 
-<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:memo: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1 to 3)** When the `WorkoutCommand#execute()` method is called, 'workout /update' command is identified, and
@@ -587,7 +587,7 @@ The following sequence diagram is the detailed procedure for Step 4's `WorkoutLi
 <br><br>
 ![Update Workout Detailed Sequence Diagram](uml/sequenceDiagrams/workouts/images/updateWorkout-Part2.png)
 
-<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, 
+<span class="box info">:memo: To improve the diagram's readability, logging-related and input-checking method calls, 
 and exception throws in `WorkoutList#updateWorkout()` have been omitted.</span>
 
 **(Before Step 4.1)** Methods from the `String` and `Integer` classes are called to parse the
@@ -659,7 +659,7 @@ A summary of the general procedure of a new plan being created and stored in Wer
 
 The following sequence diagram illustrates how the `plan /new` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -668,7 +668,7 @@ The following sequence diagram illustrates how the `plan /new` command works in 
 **(Before Step 1)** The user's input (in this case will be a `plan /new` command) is obtained and parsed to obtain
 a `PlanCommand` object that contains the user's input.
 
-<span class="info box">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="info box">:memo: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1)** When the `PlanCommand#execute()` method is called, it will identify
@@ -679,7 +679,7 @@ The following sequence diagram is the detailed procedure for Step 2's `PlanList#
 <br><br>
 ![Create And Add Plan Detailed Sequence Diagram](uml/sequenceDiagrams/plans/images/createPlan-Part2.png)
 
-<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
+<span class="box info">:memo: To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
  `PlanList#createAndAddPlan()` have been omitted.</span>
 
 **(Before Steps 2.1 to 2.2)** The user argument parameter of the `PlanList#createAndAddPlan(userArgument)`
@@ -745,7 +745,7 @@ A summary of the general procedure of listing all plans in the application is as
 
 The following sequence diagram illustrates how the `plan /list` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -754,7 +754,7 @@ The following sequence diagram illustrates how the `plan /list` command works in
 **(Before Step 1)** The user's input (in this case will be a `plan /list` command) is obtained and parsed to obtain
 a `PlanCommand` object that contains the user's input.
 
-<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:memo: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Steps 1 to 2)** When the `PlanCommand#execute()` method is called, it will identify
@@ -832,7 +832,7 @@ A summary of the general procedure of updating a plan for a particular day to th
 
 The following sequence illustrates how the schedule /update command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -919,7 +919,7 @@ command `schedule /list`.
 
 The following sequence illustrates how the `schedule /list` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -980,7 +980,7 @@ A summary of the general procedure of clearing a plan scheduled for a particular
 
 The following sequence illustrates how the `schedule /clear` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -1033,7 +1033,7 @@ A summary of the general procedure of clearing all the plans stored in the sched
 
 The following sequence illustrates how the `schedule /clearall` command works in greater detail:
 
-<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:memo: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -24,10 +24,10 @@ When reading this document, there are several icons that you may encounter.
 Below are the icons and their meanings:
 
 
-<span class="box warning">⚠️**Warning**: Information that you may want to pay attention to in order to prevent 
+<span class="box warning">:warning: **Warning**: Information that you may want to pay attention to in order to prevent 
 possible issues from arising when using the application.</span>
 
-<span class="box info">🧾  **Note**: Additional information that may be useful for you.</span>
+<span class="box info">:receipt: **Note**: Additional information that may be useful for you.</span>
 
 
 ## Acknowledgements
@@ -45,7 +45,7 @@ The following websites and codebases were referenced and adapted for our project
 - [X] An IDE of your choice, though IntelliJ IDEA is recommended as this project is developed
 with this IDE.
 
-<span class="box info"> 🧾 IDE-related references in this developer guide IDE will be tailored for IntelliJ IDEA.</span>
+<span class="box info">:receipt: IDE-related references in this developer guide IDE will be tailored for IntelliJ IDEA.</span>
 
 ### Setting Up
 1. Fork the [WerkIt! GitHub repository](https://github.com/AY2122S2-CS2113T-T09-2/tp).
@@ -193,8 +193,9 @@ the user's input as a `String` object to `WerkIt#startContinuousUserPrompt()`. T
 object that is a subclass of the `Command` class. If there is no issue with the formatting of the user's input,
 this subclass-of-`Command` object is returned to `WerkIt#startContinuousUserPrompt()`.
 
-<span class="box info">A detailed implementation of the parsing and creation of subclass-of-`Command` object process can be found in
-<span>'[Parsing User Input and Getting the Right Command](#parsing-user-input-and-getting-the-right-command)'.</span>
+<span class="box info">:receipt: A detailed implementation of the parsing and creation of subclass-of-`Command` 
+object process can be found in 
+'[Parsing User Input and Getting the Right Command](#parsing-user-input-and-getting-the-right-command)'.</span>
 
 Next, `WerkIt#startContinuousUserPrompt()` calls on the `execute()` method of the subclass-of-`Command` object to
 perform the user's requested action. If the execution goes smoothly, this completes the user's inputted command.
@@ -227,7 +228,7 @@ for subsequent prompts.
 
 ![Obtain and Parse User Input](uml/sequenceDiagrams/miscellaneous/images/obtainAndParseUserInput.png)
 
-<span class="box info"> 🧾 To improve the readability of the sequence diagram, the construction of the respective
+<span class="box info">:receipt: To improve the readability of the sequence diagram, the construction of the respective
 objects which are subclasses of the `Command` class between Steps 4 and 17 are not included in the diagram.</span>
 
 **(Steps 1 and 2)** When a user enters something into the terminal (when prompted), `UI#getUserInput()` will take in 
@@ -263,7 +264,7 @@ it is returned to `Parser#parseUserInput()`.
 
 **(Step 18)** The object created is then returned to `WerkIt#startContinuousUserInput()`.
 
-<span class="box info"> 🧾 (About the sequence diagram) Strictly speaking, the object is returned right after whichever 
+<span class="box info">:receipt: (About the sequence diagram) Strictly speaking, the object is returned right after whichever 
 'create command' method is invoked. However, to improve the readability of the diagram, only one return line is shown,
 since all alternate paths will return an object that is a subclass of the `Command` class.</span>
 
@@ -319,7 +320,7 @@ A summary of the general procedure of a new workout being inputted and stored in
 
 The following sequence diagram illustrates how the `workout /new` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that are deemed to be trivial 
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that are deemed to be trivial 
 have been removed from the sequence diagram. Some reference frames will be elaborated further 
 down this section. Reference frames that will not be elaborated on will be made known.</span>
 
@@ -328,7 +329,7 @@ down this section. Reference frames that will not be elaborated on will be made 
 **(Before Step 1)** The user's input (in this case will be a `workout /new` command) is obtained and parsed to obtain
 a `WorkoutCommand` object that contains the user's input.
 
-<span class="box info"> 🧾 For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
 ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1)** When `WorkoutCommand#execute()` is called, because this is a `workout /new` command, the method will call
@@ -337,7 +338,7 @@ a `WorkoutCommand` object that contains the user's input.
 The following sequence diagram is the detailed procedures for Step 2's `WorkoutList#createAndAddWorkout()`:
 ![createAndAddWorkout() Sequence Diagram (Part 1)](uml/sequenceDiagrams/workouts/images/CreateAndAddWorkout.png)
 
-<span class="box info"> 🧾 To improve the diagram's readability, logging-related and input-checking method calls, and 
+<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, and 
 exception throws in `WorkoutList#createAndAddWorkout()` have been omitted.</span> 
 
 **(Before Step 2.1)** Methods from the `String` and `Integer` classes are called to parse the
@@ -480,7 +481,7 @@ A summary of the general procedure of an existing workout being removed from Wer
 
 The following sequence diagram illustrates how the `workout /delete` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -489,7 +490,7 @@ The following sequence diagram illustrates how the `workout /delete` command wor
 **(Before Step 1)** The user's input (in this case will be a `workout /delete` command) is obtained and parsed to obtain
 a `WorkoutCommand` object that contains the user's input.
 
-<span class="box info"> 🧾 For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1)** When the `WorkoutCommand#execute()` method is called, it will identify
@@ -500,7 +501,7 @@ The following sequence diagram is the detailed procedure for Step 2's `WorkoutLi
 <br><br>
 ![Delete Workout Detailed Sequence Diagram](uml/sequenceDiagrams/workouts/images/deleteWorkout-Part2.png)
 
-<span class="box info"> 🧾 To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
+<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
  `WorkoutList#deleteWorkout()` have been omitted.</span>
 
 **(Steps 2.1 to 2.2)** The `Integer#parseInt()` method is called to parse the user argument parameter given to `WorkoutList#deleteWorkout(userArgument)`.
@@ -565,7 +566,7 @@ is as follows:<br><br>
 
 The following sequence diagram illustrates how the `workout /update` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial 
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial 
 have been removed from the sequence diagram. Some reference frames will be elaborated further down this section.</span>
 
 ![Update Workout Sequence Diagram](uml/sequenceDiagrams/workouts/images/updateWorkout-Part1.png)
@@ -573,7 +574,7 @@ have been removed from the sequence diagram. Some reference frames will be elabo
 **(Before Step 1)** The user's input (in this case will be a `workout /update` command) is obtained and parsed to obtain
 a `WorkoutCommand` object that contains the user's input.
 
-<span class="box info"> 🧾 For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1 to 3)** When the `WorkoutCommand#execute()` method is called, 'workout /update' command is identified, and
@@ -586,7 +587,7 @@ The following sequence diagram is the detailed procedure for Step 4's `WorkoutLi
 <br><br>
 ![Update Workout Detailed Sequence Diagram](uml/sequenceDiagrams/workouts/images/updateWorkout-Part2.png)
 
-<span class="box info"> 🧾 To improve the diagram's readability, logging-related and input-checking method calls, 
+<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, 
 and exception throws in `WorkoutList#updateWorkout()` have been omitted.</span>
 
 **(Before Step 4.1)** Methods from the `String` and `Integer` classes are called to parse the
@@ -658,7 +659,7 @@ A summary of the general procedure of a new plan being created and stored in Wer
 
 The following sequence diagram illustrates how the `plan /new` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -667,7 +668,7 @@ The following sequence diagram illustrates how the `plan /new` command works in 
 **(Before Step 1)** The user's input (in this case will be a `plan /new` command) is obtained and parsed to obtain
 a `PlanCommand` object that contains the user's input.
 
-<span class="info box"> 🧾 For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="info box">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Step 1)** When the `PlanCommand#execute()` method is called, it will identify
@@ -678,7 +679,7 @@ The following sequence diagram is the detailed procedure for Step 2's `PlanList#
 <br><br>
 ![Create And Add Plan Detailed Sequence Diagram](uml/sequenceDiagrams/plans/images/createPlan-Part2.png)
 
-<span class="box info"> 🧾 To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
+<span class="box info">:receipt: To improve the diagram's readability, logging-related and input-checking method calls, and exception throws in
  `PlanList#createAndAddPlan()` have been omitted.</span>
 
 **(Before Steps 2.1 to 2.2)** The user argument parameter of the `PlanList#createAndAddPlan(userArgument)`
@@ -744,7 +745,7 @@ A summary of the general procedure of listing all plans in the application is as
 
 The following sequence diagram illustrates how the `plan /list` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -753,7 +754,7 @@ The following sequence diagram illustrates how the `plan /list` command works in
 **(Before Step 1)** The user's input (in this case will be a `plan /list` command) is obtained and parsed to obtain
 a `PlanCommand` object that contains the user's input.
 
-<span class="box info"> 🧾 For more information on the obtaining and parsing functionality of WerkIt!, please refer to
+<span class="box info">:receipt: For more information on the obtaining and parsing functionality of WerkIt!, please refer to
  ["Parsing User Input and Getting the Right Command"](#parsing-user-input-and-getting-the-right-command) section.</span>
 
 **(Steps 1 to 2)** When the `PlanCommand#execute()` method is called, it will identify
@@ -831,7 +832,7 @@ A summary of the general procedure of updating a plan for a particular day to th
 
 The following sequence illustrates how the schedule /update command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -918,7 +919,7 @@ command `schedule /list`.
 
 The following sequence illustrates how the `schedule /list` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -979,7 +980,7 @@ A summary of the general procedure of clearing a plan scheduled for a particular
 
 The following sequence illustrates how the `schedule /clear` command works in greater detail:
 
-<span class="box info"> To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 
@@ -1032,7 +1033,7 @@ A summary of the general procedure of clearing all the plans stored in the sched
 
 The following sequence illustrates how the `schedule /clearall` command works in greater detail:
 
-<span class="box info"> 🧾 To simplify the sequence diagram, some method invocations that deemed to be trivial
+<span class="box info">:receipt: To simplify the sequence diagram, some method invocations that deemed to be trivial
  have been removed from the sequence diagram. Reference frames will be elaborated further
  down this section.</span>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1151,13 +1151,13 @@ with the WerkIt! JAR file inside it, and run the application from the directory.
 When you launch WerkIt! in subsequent sessions, please ensure that you run it from the same directory
 that you did when starting WerkIt! for the first time.
 
-<span class="box warning">⚠️**Warning:** It is highly recommended that you do not directly modify these files on your own as it may lead to
-instabilities in the application. If you do decide to modify the files, **please make a backup of the `werkItResources`
-directory** before modifying the files.</span>
+<span class="box warning">⚠️**Important:** Please **do not** directly modify these files on your own as it will lead
+to instabilities in the application.</span>
 
-In the event that your application becomes unstable due to accidental file modifications, please replace the
-`werkItResources` directory with your backup copy. In a worst case scenario (i.e. if you don't have a proper backup
-copy), delete the `werkItResources` directory and restart WerkIt! to recreate the directory and files from fresh.
+Do make regular backups of the `werkItResources` directory. In the event of data loss, please replace the
+`werkItResources` directory with your most recent backup copy. In the worst case scenario (i.e. if you don't have a 
+proper backup copy), delete the `werkItResources` directory and restart WerkIt! to recreate the directory and files from 
+fresh.
 
 ---
 
@@ -1198,8 +1198,8 @@ directory, replace your existing `werkItResources` directory with the backup cop
 reset your local file data by deleting the `werkItResources` directory and starting up WerkIt! to recreate the
 necessary files in their default numberings.
 
-Do note that these suggestions will lead to a **loss of your saved application data** and you may need to re-enter the lost
-data.
+Do note that these suggestions will lead to a **loss of your saved application data** and you may need to re-enter the 
+lost data.
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -124,7 +124,7 @@ contains two types of formatting.
 
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
-However, plan names may have more than a single whitespace in between words.<br/><br/>
+However, plan names may have more than a single whitespace in between words and numbers.<br/><br/>
 :x:**Incorrect Examples**<br/>
 - `workout /new     push up   /reps   1000`<br/><br/>
 - `plan    /list`<br/><br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,13 +125,13 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
-**Incorrect Examples**<br/><br/>
+**Incorrect Examples**
 <span class="box" style="background-color:#FF6961">
 `workout /new     push up   /reps   1000`<br/><br/>
 `plan    /list`<br/><br/>
 `plan /new Leg Day    /workouts    1, 2, 3`
 </span>
-**Correct Examples**<br/><br/>
+**Correct Examples**
 <span class="box" style="background-color:#77DD77">
 `workout /new push up /reps 1000`<br/><br/>
 `plan /list`<br/><br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,13 +126,13 @@ contains two types of formatting.
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
 **Incorrect Examples**<br/><br/>
-<span class="box" style="color:#FF6961">
+<span class="box" style="background-color:#FF6961">
 `workout /new     push up   /reps   1000`<br/><br/>
 `plan    /list`<br/><br/>
 `plan /new Leg Day    /workouts    1, 2, 3`
 </span>
 **Correct Examples**<br/><br/>
-<span class="box" style="color:#77DD77">
+<span class="box" style="background-color:#77DD77">
 `workout /new push up /reps 1000`<br/><br/>
 `plan /list`<br/><br/>
 `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,14 +125,15 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words and numbers.<br/><br/>
-:x:**Incorrect Examples**<br/>
-- `workout /new     push up   /reps   1000`<br/><br/>
-- `plan    /list`<br/><br/>
-- `plan /new Leg Day    /workouts    1, 2, 3`<br/><br/>
-:white_check_mark:**Correct Examples**<br/>
-- `workout /new push up /reps 1000`<br/><br/>
-- `plan /list`<br/><br/>
-- `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
+:x: **Incorrect Examples**<br/>
+- `workout /new     push up   /reps   1000`
+- `plan    /list`
+- `plan /new Leg Day    /workouts    1, 2, 3`
+
+:white_check_mark: **Correct Examples**<br/>
+- `workout /new push up /reps 1000`
+- `plan /list`
+- `plan /new Leg Day /workouts 1, 2, 3`
 - `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,12 +125,12 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words and numbers.<br/><br/>
-:x: **Incorrect Examples**<br/>
+:x:  **Incorrect Examples**<br/>
 - `workout /new     push up   /reps   1000`
 - `plan    /list`
 - `plan /new Leg Day    /workouts    1, 2, 3`
 
-:white_check_mark: **Correct Examples**<br/>
+:white_check_mark:  **Correct Examples**<br/>
 - `workout /new push up /reps 1000`
 - `plan /list`
 - `plan /new Leg Day /workouts 1, 2, 3`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -122,8 +122,8 @@ contains two types of formatting.
 * [Schedule Commands](#schedule-commands)
 * [Search Commands](#search-commands)
 
-<span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`s, and
-`<conditions>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
+<span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
+`<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
 **Examples**
 <span class="box>
@@ -138,6 +138,7 @@ However, plan names may have more than a single whitespace in between words.<br/
 :x: `plan /new Leg Day   /workouts   1, 2, 3`<br/<br/>
 :white_check_mark: `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
 :white_check_mark: `plan /new Leg     Day /workouts 1, 2, 3`
+</span>
 </span>
 
 #### Workout Commands

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1142,6 +1142,8 @@ werkItResources/        // Primary resource directory for WerkIt!
     ├── workouts.txt    // Text file containing a list of user-created workouts
     ├── plans.txt       // Text file containing a list of user-created plans
     └── schedule.txt    // Text file containing a 7-day schedule of user-assigned plans for each day
+werkItLogs/
+    └── logs.log        // Log file containing logs created by the application.
 ```
 
 Do note that the directory (and by extension, the files) will be created in your terminal's

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,19 +125,15 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
-**Incorrect Examples**
-<span class="box" style="background-color:#FF6961">
-`workout /new     push up   /reps   1000`<br/><br/>
-`plan    /list`<br/><br/>
-`plan /new Leg Day    /workouts    1, 2, 3`
-</span>
-**Correct Examples**
-<span class="box" style="background-color:#77DD77">
-`workout /new push up /reps 1000`<br/><br/>
-`plan /list`<br/><br/>
-`plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
-`plan /new Leg     Day /workouts 1, 2, 3`
-</span>
+:x:**Incorrect Examples**<br/>
+- `workout /new     push up   /reps   1000`<br/><br/>
+- `plan    /list`<br/><br/>
+- `plan /new Leg Day    /workouts    1, 2, 3`<br/><br/>
+:white_check_mark:**Correct Examples**<br/>
+- `workout /new push up /reps 1000`<br/><br/>
+- `plan /list`<br/><br/>
+- `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
+- `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 
 #### Workout Commands

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,7 +125,19 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`s, and
 `<conditions>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
-d
+**Examples**
+<span class="box>
+:x: `workout /new    push up   /reps   1000`<br/><br/>
+:white_check_mark: `workout /new push up /reps 1000`
+</span>
+<span class="box">
+:x: `plan     /list`</span>
+:white_check_mark: `plan /list`</span>
+</span>
+<span class="box">
+:x: `plan /new Leg Day   /workouts   1, 2, 3`<br/<br/>
+:white_check_mark: `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
+:white_check_mark: `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 
 #### Workout Commands

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,12 +125,12 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words and numbers.<br/><br/>
-**Incorrect Examples**<br/>
+**Examples of Incorrect Usage**<br/>
 :x: `workout /new     push up   /reps   1000`<br/>
 :x: `plan    /list`<br/>
 :x: `plan /new Leg Day    /workouts    1, 2, 3`
 <br/><br/>
-**Correct Examples**<br/>
+**Examples of Correct Usage**<br/>
 :ballot_box_with_check: `workout /new push up /reps 1000`<br/>
 :ballot_box_with_check: `plan /list`<br/>
 :ballot_box_with_check: `plan /new Leg Day /workouts 1, 2, 3`<br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,16 +125,16 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words and numbers.<br/><br/>
-:x:  **Incorrect Examples**<br/>
-- `workout /new     push up   /reps   1000`
-- `plan    /list`
-- `plan /new Leg Day    /workouts    1, 2, 3`
-
-:white_check_mark:  **Correct Examples**<br/>
-- `workout /new push up /reps 1000`
-- `plan /list`
-- `plan /new Leg Day /workouts 1, 2, 3`
-- `plan /new Leg     Day /workouts 1, 2, 3`
+**Incorrect Examples**<br/>
+:x:  `workout /new     push up   /reps   1000`<br/>
+:x:  `plan    /list`<br/>
+:x:  `plan /new Leg Day    /workouts    1, 2, 3`
+<br/><br/>
+**Correct Examples**<br/>
+:white_check_mark:  `workout /new push up /reps 1000`<br/>
+:white_check_mark:  `plan /list`<br/>
+:white_check_mark:  `plan /new Leg Day /workouts 1, 2, 3`<br/>
+:white_check_mark:  `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 
 #### Workout Commands

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -32,7 +32,7 @@ Below are the icons and their meanings:
 <span class="box warning">:warning: **Warning**: Information that you may want to pay attention to in order to prevent
 possible issues from arising when using the application.</span>
 
-<span class="box info">:receipt: **Note**: Additional information that may be useful for you.</span>
+<span class="box info">:memo: **Note**: Additional information that may be useful for you.</span>
 
 ---
 
@@ -1191,7 +1191,7 @@ fresh.
 the [Quick Start Guide](#quick-start-guide). If you have not installed it, [click here][1] to install it via the
 Microsoft Store.
 
-<span class="box info">:receipt: **Why are these symbols appearing?** Without being too technical, these symbols are appearing 
+<span class="box info">:memo: **Why are these symbols appearing?** Without being too technical, these symbols are appearing 
 because the terminal you are using is unable to process a particular encoding scheme (i.e. ANSI escape codes). 
 These symbols you see are actually colour codes to colour certain texts on the terminal. Terminals that can properly 
 read these codes will not show you these symbols and instead show you something like this:<br/><br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -127,17 +127,17 @@ contains two types of formatting.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
 **Examples**<br/><br/>
 <span class="box>
-:x: `workout /new    push up   /reps   1000`<br/><br/>
-:white_check_mark: `workout /new push up /reps 1000`
+:x:  `workout /new    push up   /reps   1000`<br/><br/>
+:white_check_mark:  `workout /new push up /reps 1000`
 </span>
 <span class="box">
-:x: `plan     /list`</span>
-:white_check_mark: `plan /list`</span>
+:x:  `plan     /list`<br/><br/>
+:white_check_mark:  `plan /list`
 </span>
 <span class="box">
-:x: `plan /new Leg Day   /workouts   1, 2, 3`<br/<br/>
-:white_check_mark: `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
-:white_check_mark: `plan /new Leg     Day /workouts 1, 2, 3`
+:x:  `plan /new Leg Day   /workouts   1, 2, 3`<br/><br/>
+:white_check_mark:  `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
+:white_check_mark:  `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 </span>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,19 +125,18 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
-**Examples**<br/><br/>
-<span class="box">
-:x:  `workout /new    push up   /reps   1000`<br/><br/>
-:white_check_mark:  `workout /new push up /reps 1000`
+**Incorrect Examples**<br/><br/>
+<span class="box" style="color:#FF6961">
+`workout /new     push up   /reps   1000`<br/><br/>
+`plan    /list`<br/><br/>
+`plan /new Leg Day    /workouts    1, 2, 3`
 </span>
-<span class="box">
-:x:  `plan     /list`<br/><br/>
-:white_check_mark:  `plan /list`
-</span>
-<span class="box">
-:x:  `plan /new Leg Day   /workouts   1, 2, 3`<br/><br/>
-:white_check_mark:  `plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
-:white_check_mark:  `plan /new Leg     Day /workouts 1, 2, 3`
+**Correct Examples**<br/><br/>
+<span class="box" style="color:#77DD77">
+`workout /new push up /reps 1000`<br/><br/>
+`plan /list`<br/><br/>
+`plan /new Leg Day /workouts 1, 2, 3`<br/><br/>
+`plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 </span>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,7 +125,7 @@ contains two types of formatting.
 <span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`, and
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
-**Examples**
+**Examples**<br/><br/>
 <span class="box>
 :x: `workout /new    push up   /reps   1000`<br/><br/>
 :white_check_mark: `workout /new push up /reps 1000`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,15 +126,15 @@ contains two types of formatting.
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words and numbers.<br/><br/>
 **Incorrect Examples**<br/>
-:x:  `workout /new     push up   /reps   1000`<br/>
-:x:  `plan    /list`<br/>
-:x:  `plan /new Leg Day    /workouts    1, 2, 3`
+:x: `workout /new     push up   /reps   1000`<br/>
+:x: `plan    /list`<br/>
+:x: `plan /new Leg Day    /workouts    1, 2, 3`
 <br/><br/>
 **Correct Examples**<br/>
-:white_check_mark:  `workout /new push up /reps 1000`<br/>
-:white_check_mark:  `plan /list`<br/>
-:white_check_mark:  `plan /new Leg Day /workouts 1, 2, 3`<br/>
-:white_check_mark:  `plan /new Leg     Day /workouts 1, 2, 3`
+:ballot_box_with_check: `workout /new push up /reps 1000`<br/>
+:ballot_box_with_check: `plan /list`<br/>
+:ballot_box_with_check: `plan /new Leg Day /workouts 1, 2, 3`<br/>
+:ballot_box_with_check: `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 
 #### Workout Commands

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,12 +16,13 @@ that WerkIt have.
 ### Terminology 
 Please take note of these few terms. It is explained as below:
 
-| Term     | Description                                                                                                              |
-|----------|--------------------------------------------------------------------------------------------------------------------------|
-| Exercise | A single unit of exercise. <br/>Example: "push up", "pull up", "sit up"                                                  |
-| Workout  | An exercise with a quantity/number of repetitions. <br/>Example: "5 push up", "5 pull up", "10 sit up"                   |
-| Plan     | A set of workouts. <br/>Example: A plan named "Arms" will contains "5 push ups, 5 pull ups"                              |
-| Schedule | Plan schedule for a day. The schedule is set for a week. <br/>Example: Arms plan will be added to Monday in the schedule |
+| Term       | Description                                                                                                              |
+|------------|--------------------------------------------------------------------------------------------------------------------------|
+| Exercise   | A single unit of exercise. <br/>Example: "push up", "pull up", "sit up"                                                  |
+| Repetition | The process of repeating an exercise. Often abbreviated to 'reps'.                                                       |
+| Workout    | An exercise with a quantity/number of repetitions. <br/>Example: "5 push up", "5 pull up", "10 sit up"                   |
+| Plan       | A set of workouts. <br/>Example: A plan named "Arms" will contains "5 push ups, 5 pull ups"                              |
+| Schedule   | Plan schedule for a day. The schedule is set for a week. <br/>Example: Arms plan will be added to Monday in the schedule |
 
 ### Notations Used In This Guide
 When reading this document, there are several icons that you may encounter.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -28,10 +28,10 @@ When reading this document, there are several icons that you may encounter.
 Below are the icons and their meanings:
 
 
-<span class="box warning">⚠️**Warning**: Information that you may want to pay attention to in order to prevent
+<span class="box warning">:warning: **Warning**: Information that you may want to pay attention to in order to prevent
 possible issues from arising when using the application.</span>
 
-<span class="box info">🧾  **Note**: Additional information that may be useful for you.</span>
+<span class="box info">:receipt: **Note**: Additional information that may be useful for you.</span>
 
 ---
 
@@ -88,12 +88,12 @@ work.
 | Apple macOS       | macOS 10.15 Catalina and above | Terminal ([User Guide](https://support.apple.com/en-sg/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)) |
 | Ubuntu Linux      | Ubuntu 20.04.3 (LTS) and above | Bash Terminal ([User Guide](https://ubuntu.com/tutorials/command-line-for-beginners#3-opening-a-terminal))          |
 
-<span class="box warning">⚠️If your operating system is not listed in the table above, it means our application has 
+<span class="box warning">:warning: If your operating system is not listed in the table above, it means our application has 
 not been tested on it, and we cannot guarantee that the application will work as intended. We highly encourage you to 
 use one of the recommended operating systems listed in the table above. 
 We apologise for any inconvenience caused.</span>
 
-<span class="box warning">⚠️(For Microsoft Windows users) In order for the application to display colours properly
+<span class="box warning">:warning: (For Microsoft Windows users) In order for the application to display colours properly
 on your screen, Windows Terminal needs to be used. The default Command Prompt and Powershell consoles will not be able
 to display WerkIt!'s coloured texts properly.</span>
 
@@ -114,13 +114,19 @@ contains two types of formatting.
 | `<condition>`    | Contents enclosed between "<>" are the inputs needed for the command to be valid. <br /> Not all commands needs input.         |
 | `/commandAction` | Content after "/" is to classify the action of the command. <br/> Such as classifying it to be list / delete / update commands |
 
-<span class="box warning">⚠️**Heads Up!** Your inputs cannot contain the pipe character `|`!</span>
+<span class="box warning">:warning: **Heads Up!** Your inputs cannot contain the pipe character `|`!</span>
 
 ### Finding Your Way Around The Application
 * [Workout Commands](#workout-commands)
 * [Plan Commands](#plan-commands)
 * [Schedule Commands](#schedule-commands)
 * [Search Commands](#search-commands)
+
+<span class="box warning">:warning: **Heads Up!** Due to the design of WerkIt!, commands, `/commandAction`s, and
+`<conditions>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
+However, plan names may have more than a single whitespace in between words.<br/><br/>
+d
+</span>
 
 #### Workout Commands
 A brief summary of all the workout commands is stated in this section. You can have a better understanding of each of the
@@ -1153,7 +1159,7 @@ with the WerkIt! JAR file inside it, and run the application from the directory.
 When you launch WerkIt! in subsequent sessions, please ensure that you run it from the same directory
 that you did when starting WerkIt! for the first time.
 
-<span class="box warning">⚠️**Important:** Please **do not** directly modify these files on your own as it will lead
+<span class="box warning">:warning: **Important:** Please **do not** directly modify these files on your own as it will lead
 to instabilities in the application.</span>
 
 Do make regular backups of the `werkItResources` directory. In the event of data loss, please replace the
@@ -1175,7 +1181,7 @@ fresh.
 the [Quick Start Guide](#quick-start-guide). If you have not installed it, [click here][1] to install it via the
 Microsoft Store.
 
-<span class="box info">🧾 **Why are these symbols appearing?** Without being too technical, these symbols are appearing 
+<span class="box info">:receipt: **Why are these symbols appearing?** Without being too technical, these symbols are appearing 
 because the terminal you are using is unable to process a particular encoding scheme (i.e. ANSI escape codes). 
 These symbols you see are actually colour codes to colour certain texts on the terminal. Terminals that can properly 
 read these codes will not show you these symbols and instead show you something like this:<br/><br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,7 +126,7 @@ contains two types of formatting.
 `<condition>` must be separated by a single whitespace. Excessive whitespaces will not be accepted by the application.
 However, plan names may have more than a single whitespace in between words.<br/><br/>
 **Examples**<br/><br/>
-<span class="box>
+<span class="box">
 :x:  `workout /new    push up   /reps   1000`<br/><br/>
 :white_check_mark:  `workout /new push up /reps 1000`
 </span>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,10 +131,10 @@ However, plan names may have more than a single whitespace in between words and 
 :x: `plan /new Leg Day    /workouts    1, 2, 3`
 <br/><br/>
 **Examples of Correct Usage**<br/>
-:ballot_box_with_check: `workout /new push up /reps 1000`<br/>
-:ballot_box_with_check: `plan /list`<br/>
-:ballot_box_with_check: `plan /new Leg Day /workouts 1, 2, 3`<br/>
-:ballot_box_with_check: `plan /new Leg     Day /workouts 1, 2, 3`
+:heavy_check_mark: `workout /new push up /reps 1000`<br/>
+:heavy_check_mark: `plan /list`<br/>
+:heavy_check_mark: `plan /new Leg Day /workouts 1, 2, 3`<br/>
+:heavy_check_mark: `plan /new Leg     Day /workouts 1, 2, 3`
 </span>
 
 #### Workout Commands

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,4 @@
 theme: jekyll-theme-cayman
 markdown: kramdown
+plugins:
+  - jemoji

--- a/docs/team/alanlowzies.md
+++ b/docs/team/alanlowzies.md
@@ -6,7 +6,7 @@ Software Engineering & Object-Oriented Programming module offered by the School 
 Singapore.
 
 ### About the Project
-WerkIt! is a command line interface (CLI) application written in Java hat allows users to create a weekly workout 
+WerkIt! is a command line interface (CLI) application written in Java that allows users to create a weekly workout 
 schedule for them to refer to and follow. More details about the project can be found in the following locations:
 * [GitHub Repository](../../)
 * [WerkIt! User Guide](../UserGuide.md)

--- a/docs/team/alanlowzies.md
+++ b/docs/team/alanlowzies.md
@@ -55,7 +55,7 @@ into text files stored on the user's local filesystem
   <br/><br/>**Sample:**<br/>
 <span class="box warning">:warning: This is an example of a warning box. Contains advice or instructions that users
 should take note of to avoid issues in the application.</span>
-<span class="box info">:memo: This is an information box. Contains information that may be useful for
+<span class="box info">:memo: This is an example of an information box. Contains information that may be useful for
 the users.</span>
 
 ### Contributions to the User Guide (UG)

--- a/docs/team/alanlowzies.md
+++ b/docs/team/alanlowzies.md
@@ -46,6 +46,7 @@ into text files stored on the user's local filesystem
   additional functionality to the API such as populating the `exercise.txt` file with default exercises. The exercises
   were thought of by Haofeng :)
 - Wrote JUnit test cases for WerkIt! APIs including (but not limited to) `WorkoutCommand`, `FileManager`, `Parser`, etc.
+- Wrote JavaDocs for most of the classes and methods that I have created.
 - Created skeleton codes and packages for the project.
 
 

--- a/docs/team/alanlowzies.md
+++ b/docs/team/alanlowzies.md
@@ -53,9 +53,9 @@ into text files stored on the user's local filesystem
 ### Enhancements Implemented
 - (Developer and User Guides) Replaced Markdown quote blocks with custom CSS boxes for informational and warning boxes.
   <br/><br/>**Sample:**<br/>
-<span class="box warning">⚠️This is an example of a warning box. Contains advice or instructions that users
+<span class="box warning">:warning: This is an example of a warning box. Contains advice or instructions that users
 should take note of to avoid issues in the application.</span>
-<span class="box info">🧾  This is an information box. Contains information that may be useful for
+<span class="box info">:memo: This is an information box. Contains information that may be useful for
 the users.</span>
 
 ### Contributions to the User Guide (UG)


### PR DESCRIPTION
This PR contains edits to the UG in the following areas:
- Users are now explicitly warned not to edit the resource application files. (#227) 
- Users are now explicitly warned to only separate commands and parameters with a single whitespace. (#228)

A preview of the User Guide can be found in my fork's [GitHub Page](https://alanlowzies.github.io/tp/UserGuide.html).