### PR TITLE
Enhance Printing of Messages when Loading Files

### DIFF
--- a/src/main/java/data/exercises/ExerciseList.java
+++ b/src/main/java/data/exercises/ExerciseList.java
@@ -109,20 +109,12 @@ public class ExerciseList {
     /**
      * Populates a set of exercises to ExerciseList.
      */
-    public void populateExerciseToList() {
-        this.addExerciseToList("push up");
-        this.addExerciseToList("bicep curl");
-        this.addExerciseToList("pull up");
-        this.addExerciseToList("squat");
-        this.addExerciseToList("lunge");
-        this.addExerciseToList("hip thrust");
-        this.addExerciseToList("sit up");
-        this.addExerciseToList("crunch");
-        this.addExerciseToList("russian twist");
-        this.addExerciseToList("running");
-        this.addExerciseToList("swimming");
-        this.addExerciseToList("jumping jack");
-        this.addExerciseToList("burpee");
+    public void populateExercisesToList() {
+        ArrayList<String> defaultExercises = getDefaultExerciseList();
+
+        for (String defaultExercise : defaultExercises) {
+            addExerciseToList(defaultExercise);
+        }
     }
 
     /**

--- a/src/main/java/storage/FileManager.java
+++ b/src/main/java/storage/FileManager.java
@@ -261,7 +261,7 @@ public class FileManager {
      * Checks if all the required directory and files already exist prior to the current session
      * of the application.
      *
-     * @return Returns true if all the required directory and files already exists. Otherwise,
+     * @return Returns true if all the required directory and files already exist. Otherwise,
      *         returns false.
      */
     public boolean checkIfAllDirectoryAndFilesExists() {
@@ -282,6 +282,21 @@ public class FileManager {
         }
 
         return true;
+    }
+
+    /**
+     * Checks if at least one of the following resource files already exist prior to the current session
+     * of the application: workouts.txt, plans.txt, or schedule.txt
+     *
+     * @return Returns true if at least one of the abovementioned files already exists. Otherwise,
+     *         returns false.
+     */
+    public boolean checkIfAtLeastOneFileExists() {
+        if (isWasWorkoutsFileAlreadyMade() || isWasPlansFileAlreadyMade() || isWasScheduleFileAlreadyMade()) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/werkit/WerkIt.java
+++ b/src/main/java/werkit/WerkIt.java
@@ -132,14 +132,16 @@ public class WerkIt {
     private void loadRequiredDirectoryAndFiles() throws IOException {
         getUI().printCheckingDirectoryAndFilesMessage();
         getFileManager().checkAndCreateDirectoriesAndFiles();
-        getUI().printEmptyLineOrStatus(fileManager.checkIfAllDirectoryAndFilesExists());
+        getUI().printEmptyLineOrStatus(getFileManager().checkIfAllDirectoryAndFilesExists());
 
-        assert (Files.exists(fileManager.getWorkoutFilePath())) : "Workout file does not exist.";
-        assert (Files.exists(fileManager.getExerciseFilePath())) : "Exercise file does not exist.";
-        assert (Files.exists(fileManager.getPlanFilePath())) : "Plan file does not exist.";
-        assert (Files.exists(fileManager.getScheduleFilePath())) : "Schedule file does not exist.";
+        assert (Files.exists(getFileManager().getWorkoutFilePath())) : "Workout file does not exist.";
+        assert (Files.exists(getFileManager().getExerciseFilePath())) : "Exercise file does not exist.";
+        assert (Files.exists(getFileManager().getPlanFilePath())) : "Plan file does not exist.";
+        assert (Files.exists(getFileManager().getScheduleFilePath())) : "Schedule file does not exist.";
 
-        getUI().printLoadingFileDataMessage();
+        if(getFileManager().checkIfAtLeastOneFileExists()) {
+            getUI().printLoadingFileDataMessage();
+        }
         populateExercises();
         if (getFileManager().isWasWorkoutsFileAlreadyMade()) {
             loadWorkoutFile();
@@ -211,7 +213,7 @@ public class WerkIt {
      * Populates a set of exercises to exerciseList.
      */
     public void populateExercises() {
-        getExerciseList().populateExerciseToList();
+        getExerciseList().populateExercisesToList();
     }
 
     /**

--- a/src/main/java/werkit/WerkIt.java
+++ b/src/main/java/werkit/WerkIt.java
@@ -139,7 +139,7 @@ public class WerkIt {
         assert (Files.exists(getFileManager().getPlanFilePath())) : "Plan file does not exist.";
         assert (Files.exists(getFileManager().getScheduleFilePath())) : "Schedule file does not exist.";
 
-        if(getFileManager().checkIfAtLeastOneFileExists()) {
+        if (getFileManager().checkIfAtLeastOneFileExists()) {
             getUI().printLoadingFileDataMessage();
         }
         populateExercises();

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -28,7 +28,6 @@ Checking for required directory and files...
 - The schedule file 'schedule.txt' has been
   created in the WerkIt! resource directory.
 
-Loading saved file data...
 ----------------------------------------------------------------------
 Now then, what can I do for you today?
 (Need help? Type 'help' for a guide!)


### PR DESCRIPTION
This PR improves on PR #267 with the following additional changes:
- Currently, if all files are created when WerkIt! is launched, the "loading saved file data..." will still be printed, even though no saved file data is being loaded.
![image](https://user-images.githubusercontent.com/30099983/162113876-b532da8e-d4f3-43e5-aaab-e97386591298.png)
This PR changes the behaviour such that that message will be printed only when there is at least one existing resource file (`workouts.txt`, `plans.txt`, or `schedule.txt`) to load data from.
- `ExerciseList#populateExercisesToList()` has been modified to utilise an existing method, rather than re-hardcoding the default exercises.